### PR TITLE
Update Dependencies to IPK versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,7 @@
         <!-- Identity branding preference management version -->
         <identity.branding.preference.management.exp.pkg.version>${project.version}
         </identity.branding.preference.management.exp.pkg.version>
-        <org.wso2.identity.branding.preference.mgt.imp.pkg.version.range>[1.0.0,2.0.0)
+        <org.wso2.identity.branding.preference.mgt.imp.pkg.version.range>[2.0.0,3.0.0)
         </org.wso2.identity.branding.preference.mgt.imp.pkg.version.range>
 
         <!-- OSGi/Equinox dependency version -->
@@ -297,8 +297,8 @@
         <pax.logging.api.version>1.10.1</pax.logging.api.version>
 
         <!-- Carbon identity framework version -->
-        <carbon.identity.framework.version>5.20.267</carbon.identity.framework.version>
-        <carbon.identity.package.import.version.range>[5.20.0, 6.0.0)</carbon.identity.package.import.version.range>
+        <carbon.identity.framework.version>6.0.0</carbon.identity.framework.version>
+        <carbon.identity.package.import.version.range>[6.0.0, 7.0.0)</carbon.identity.package.import.version.range>
 
         <!-- Commons version -->
         <commons-lang.wso2.version>2.6.0.wso2v1</commons-lang.wso2.version>


### PR DESCRIPTION
The identity components are bumped to major versions created for IPK.

Related issue: https://github.com/wso2-enterprise/identity-k8s-access-runtime/issues/16