### PR TITLE
Improve branding BE to store application wise branding preferences.

### DIFF
--- a/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/BrandingPreferenceManager.java
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/BrandingPreferenceManager.java
@@ -65,13 +65,12 @@ public interface BrandingPreferenceManager {
     /**
      * This API is used to retrieve a resolved branding preference for an application.
      *
-     * @param type   Type of the branding preference.
      * @param name   Name of the application.
      * @param locale Language preference of the branding.
      * @return The resolved branding preference. If not exists return the default branding preference.
      * @throws BrandingPreferenceMgtException if any error occurred.
      */
-    BrandingPreference resolveApplicationBrandingPreference(String type, String name, String locale)
+    BrandingPreference resolveApplicationBrandingPreference(String name, String locale)
             throws BrandingPreferenceMgtException;
 
     /**

--- a/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/BrandingPreferenceManager.java
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/BrandingPreferenceManager.java
@@ -65,13 +65,16 @@ public interface BrandingPreferenceManager {
     /**
      * This API is used to retrieve a resolved branding preference for an application.
      *
-     * @param name   Name of the application.
-     * @param locale Language preference of the branding.
+     * @param identifier Application identifier.
+     * @param locale     Language preference of the branding.
      * @return The resolved branding preference. If not exists return the default branding preference.
      * @throws BrandingPreferenceMgtException if any error occurred.
      */
-    BrandingPreference resolveApplicationBrandingPreference(String name, String locale)
-            throws BrandingPreferenceMgtException;
+    default BrandingPreference resolveApplicationBrandingPreference(String identifier, String locale)
+            throws BrandingPreferenceMgtException {
+
+        throw new NotImplementedException("This functionality is not implemented.");
+    }
 
     /**
      * This API is used to replace a given branding preference.

--- a/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/BrandingPreferenceManager.java
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/BrandingPreferenceManager.java
@@ -61,6 +61,18 @@ public interface BrandingPreferenceManager {
             throws BrandingPreferenceMgtException;
 
     /**
+     * This API is used to retrieve a resolved branding preference for an application.
+     *
+     * @param type   Type of the branding preference.
+     * @param name   Name of the application.
+     * @param locale Language preference of the branding.
+     * @return The resolved branding preference. If not exists return the default branding preference.
+     * @throws BrandingPreferenceMgtException if any error occurred.
+     */
+    BrandingPreference resolveApplicationBrandingPreference(String type, String name, String locale)
+            throws BrandingPreferenceMgtException;
+
+    /**
      * This API is used to replace a given branding preference.
      *
      * @param brandingPreference Branding preference to be added.

--- a/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/BrandingPreferenceManagerImpl.java
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/BrandingPreferenceManagerImpl.java
@@ -199,18 +199,18 @@ public class BrandingPreferenceManagerImpl implements BrandingPreferenceManager 
     }
 
     @Override
-    public BrandingPreference resolveApplicationBrandingPreference(String name, String locale)
+    public BrandingPreference resolveApplicationBrandingPreference(String identifier, String locale)
             throws BrandingPreferenceMgtException {
 
         try {
-            return getBrandingPreference(APPLICATION_TYPE, name, locale);
+            return getBrandingPreference(APPLICATION_TYPE, identifier, locale);
         } catch (BrandingPreferenceMgtClientException e) {
             if (ERROR_CODE_BRANDING_PREFERENCE_NOT_EXISTS.getCode().equals(e.getErrorCode())) {
                 if (LOG.isDebugEnabled()) {
-                    LOG.debug("Can not find a branding preference configurations for Application: " + name);
+                    LOG.debug("Can not find a branding preference configurations for Application: " + identifier);
                 }
                 // Return default branding preference.(organization level branding preferences)
-                return resolveBrandingPreference(ORGANIZATION_TYPE, name, locale);
+                return resolveBrandingPreference(ORGANIZATION_TYPE, getTenantDomain(), locale);
             }
             throw e;
         }
@@ -594,9 +594,9 @@ public class BrandingPreferenceManagerImpl implements BrandingPreferenceManager 
         return BRANDING_RESOURCE_TYPE;
     }
 
-    private boolean isApplicationExists(String applicationName, String tenantDomain) {
+    private boolean isApplicationExists(String identifier, String tenantDomain) {
 
-        //TODO: Implement this method to check the existence of application before add application branding preferences.
+        //TODO: Implement this to check the existence of application(https://github.com/wso2/product-is/issues/19366).
         return true;
     }
 

--- a/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/BrandingPreferenceManagerImpl.java
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/BrandingPreferenceManagerImpl.java
@@ -199,11 +199,11 @@ public class BrandingPreferenceManagerImpl implements BrandingPreferenceManager 
     }
 
     @Override
-    public BrandingPreference resolveApplicationBrandingPreference(String type, String name, String locale)
+    public BrandingPreference resolveApplicationBrandingPreference(String name, String locale)
             throws BrandingPreferenceMgtException {
 
         try {
-            return getBrandingPreference(type, name, locale);
+            return getBrandingPreference(APPLICATION_TYPE, name, locale);
         } catch (BrandingPreferenceMgtClientException e) {
             if (ERROR_CODE_BRANDING_PREFERENCE_NOT_EXISTS.getCode().equals(e.getErrorCode())) {
                 if (LOG.isDebugEnabled()) {
@@ -211,9 +211,8 @@ public class BrandingPreferenceManagerImpl implements BrandingPreferenceManager 
                 }
                 // Return default branding preference.(organization level branding preferences)
                 return resolveBrandingPreference(ORGANIZATION_TYPE, name, locale);
-            } else {
-                throw e;
             }
+            throw e;
         }
     }
 

--- a/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/BrandingPreferenceManagerImpl.java
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/BrandingPreferenceManagerImpl.java
@@ -47,8 +47,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.APPLICATION_BRANDING_RESOURCE_TYPE;
+import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.APPLICATION_TYPE;
 import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.BRANDING_PREFERENCE;
 import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.BRANDING_RESOURCE_TYPE;
+import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.ErrorMessages.ERROR_CODE_APPLICATION_NOT_FOUND;
 import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.ErrorMessages.ERROR_CODE_BRANDING_PREFERENCE_ALREADY_EXISTS;
 import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.ErrorMessages.ERROR_CODE_BRANDING_PREFERENCE_NOT_EXISTS;
 import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.ErrorMessages.ERROR_CODE_ERROR_ADDING_BRANDING_PREFERENCE;
@@ -62,6 +65,7 @@ import static org.wso2.carbon.identity.branding.preference.management.core.const
 import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.ErrorMessages.ERROR_CODE_NOT_ALLOWED_BRANDING_PREFERENCE;
 import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.NEW_BRANDING_PREFERENCE;
 import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.OLD_BRANDING_PREFERENCE;
+import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.ORGANIZATION_TYPE;
 import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.PRE_ADD_BRANDING_PREFERENCE;
 import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.PRE_UPDATE_BRANDING_PREFERENCE;
 import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.RESOURCE_ALREADY_EXISTS_ERROR_CODE;
@@ -84,11 +88,21 @@ public class BrandingPreferenceManagerImpl implements BrandingPreferenceManager 
 
         String resourceName = getResourceName
                 (brandingPreference.getType(), brandingPreference.getName(), brandingPreference.getLocale());
+        String resourceType = getResourceType(brandingPreference.getType());
         String tenantDomain = getTenantDomain();
         // Check whether a branding resource already exists with the same name in the particular tenant to be added.
-        if (isResourceExists(BRANDING_RESOURCE_TYPE, resourceName)) {
+        if (isResourceExists(resourceType, resourceName)) {
             throw handleClientException(ERROR_CODE_BRANDING_PREFERENCE_ALREADY_EXISTS, tenantDomain);
         }
+
+        if (APPLICATION_TYPE.equals(brandingPreference.getType())) {
+            // Check whether an application exists with the given name.
+            if (!isApplicationExists(brandingPreference.getName(), tenantDomain)) {
+                throw handleClientException
+                        (ERROR_CODE_APPLICATION_NOT_FOUND, brandingPreference.getName(), tenantDomain);
+            }
+        }
+
         String preferencesJSON = generatePreferencesJSONFromPreference(brandingPreference.getPreference());
         if (!BrandingPreferenceMgtUtils.isValidJSONString(preferencesJSON)) {
             throw handleClientException(ERROR_CODE_INVALID_BRANDING_PREFERENCE, tenantDomain);
@@ -100,7 +114,7 @@ public class BrandingPreferenceManagerImpl implements BrandingPreferenceManager 
         try {
             InputStream inputStream = new ByteArrayInputStream(preferencesJSON.getBytes(StandardCharsets.UTF_8));
             Resource brandingPreferenceResource = buildResourceFromBrandingPreference(resourceName, inputStream);
-            getConfigurationManager().addResource(BRANDING_RESOURCE_TYPE, brandingPreferenceResource);
+            getConfigurationManager().addResource(resourceType, brandingPreferenceResource);
         } catch (ConfigurationManagementException e) {
             if (RESOURCE_ALREADY_EXISTS_ERROR_CODE.equals(e.getErrorCode())) {
                 if (LOG.isDebugEnabled()) {
@@ -121,10 +135,11 @@ public class BrandingPreferenceManagerImpl implements BrandingPreferenceManager 
             throws BrandingPreferenceMgtException {
 
         String resourceName = getResourceName(type, name, locale);
+        String resourceType = getResourceType(type);
         String tenantDomain = getTenantDomain();
         try {
             // Return default branding preference.
-            List<ResourceFile> resourceFiles = getConfigurationManager().getFiles(BRANDING_RESOURCE_TYPE, resourceName);
+            List<ResourceFile> resourceFiles = getConfigurationManager().getFiles(resourceType, resourceName);
             if (resourceFiles.isEmpty()) {
                 throw handleClientException(ERROR_CODE_BRANDING_PREFERENCE_NOT_EXISTS, tenantDomain);
             }
@@ -133,7 +148,7 @@ public class BrandingPreferenceManagerImpl implements BrandingPreferenceManager 
             }
 
             InputStream inputStream = getConfigurationManager().getFileById
-                    (BRANDING_RESOURCE_TYPE, resourceName, resourceFiles.get(0).getId());
+                    (resourceType, resourceName, resourceFiles.get(0).getId());
             if (inputStream == null) {
                 throw handleClientException(ERROR_CODE_BRANDING_PREFERENCE_NOT_EXISTS, tenantDomain);
             }
@@ -166,14 +181,34 @@ public class BrandingPreferenceManagerImpl implements BrandingPreferenceManager 
     }
 
     @Override
+    public BrandingPreference resolveApplicationBrandingPreference(String type, String name, String locale)
+            throws BrandingPreferenceMgtException {
+
+        try {
+            return getBrandingPreference(type, name, locale);
+        } catch (BrandingPreferenceMgtClientException e) {
+            if (ERROR_CODE_BRANDING_PREFERENCE_NOT_EXISTS.getCode().equals(e.getErrorCode())) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Can not find a branding preference configurations for Application: " + name);
+                }
+                // Return default branding preference.(organization level branding preferences)
+                return resolveBrandingPreference(ORGANIZATION_TYPE, name, locale);
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    @Override
     public BrandingPreference replaceBrandingPreference(BrandingPreference brandingPreference)
             throws BrandingPreferenceMgtException {
 
         String resourceName = getResourceName
                 (brandingPreference.getType(), brandingPreference.getName(), brandingPreference.getLocale());
+        String resourceType = getResourceType(brandingPreference.getType());
         String tenantDomain = getTenantDomain();
         // Check whether the branding resource exists in the particular tenant.
-        if (!isResourceExists(BRANDING_RESOURCE_TYPE, resourceName)) {
+        if (!isResourceExists(resourceType, resourceName)) {
             throw handleClientException(ERROR_CODE_BRANDING_PREFERENCE_NOT_EXISTS, tenantDomain);
         }
 
@@ -190,7 +225,7 @@ public class BrandingPreferenceManagerImpl implements BrandingPreferenceManager 
         try {
             InputStream inputStream = new ByteArrayInputStream(preferencesJSON.getBytes(StandardCharsets.UTF_8));
             Resource brandingPreferenceResource = buildResourceFromBrandingPreference(resourceName, inputStream);
-            getConfigurationManager().replaceResource(BRANDING_RESOURCE_TYPE, brandingPreferenceResource);
+            getConfigurationManager().replaceResource(resourceType, brandingPreferenceResource);
         } catch (ConfigurationManagementException e) {
             throw handleServerException(ERROR_CODE_ERROR_UPDATING_BRANDING_PREFERENCE, tenantDomain, e);
         }
@@ -205,14 +240,15 @@ public class BrandingPreferenceManagerImpl implements BrandingPreferenceManager 
             throws BrandingPreferenceMgtException {
 
         String resourceName = getResourceName(type, name, locale);
+        String resourceType = getResourceType(type);
         String tenantDomain = getTenantDomain();
         // Check whether the branding resource exists in the particular tenant.
-        if (!isResourceExists(BRANDING_RESOURCE_TYPE, resourceName)) {
+        if (!isResourceExists(resourceType, resourceName)) {
             throw handleClientException(ERROR_CODE_BRANDING_PREFERENCE_NOT_EXISTS, tenantDomain);
         }
 
         try {
-            getConfigurationManager().deleteResource(BRANDING_RESOURCE_TYPE, resourceName);
+            getConfigurationManager().deleteResource(resourceType, resourceName);
         } catch (ConfigurationManagementException e) {
             throw handleServerException(ERROR_CODE_ERROR_DELETING_BRANDING_PREFERENCE, tenantDomain);
         }
@@ -322,12 +358,30 @@ public class BrandingPreferenceManagerImpl implements BrandingPreferenceManager 
      */
     private String getResourceName(String type, String name, String locale) {
 
-        /*
-          Currently, this API provides the support to only configure tenant wise branding preference for 'en-US' locale.
-          So always use resource name as default resource name.
-          Default resource name is the name used to save organization level branding for 'en-US' language.
-         */
+        if (APPLICATION_TYPE.equals(type)) {
+            return name.toLowerCase() + RESOURCE_NAME_SEPARATOR + locale;
+        }
         return getTenantId() + RESOURCE_NAME_SEPARATOR + locale;
+    }
+
+    /**
+     * Return resource type for the given branding type.
+     *
+     * @param type Branding Type(Organization branding/Application branding).
+     * @return resource type of the branding resource.
+     */
+    private String getResourceType(String type) {
+
+        if (APPLICATION_TYPE.equals(type)) {
+            return APPLICATION_BRANDING_RESOURCE_TYPE;
+        }
+        return BRANDING_RESOURCE_TYPE;
+    }
+
+    private boolean isApplicationExists(String applicationName, String tenantDomain) {
+
+        //TODO: Implement this method to check the existence of application before add application branding preferences.
+        return true;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/constant/BrandingPreferenceMgtConstants.java
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/constant/BrandingPreferenceMgtConstants.java
@@ -73,6 +73,8 @@ public class BrandingPreferenceMgtConstants {
                 "Requested branding preference configuration: %s is not allowed for the organization."),
         ERROR_CODE_ERROR_CLEARING_BRANDING_PREFERENCE_RESOLVER_CACHE_HIERARCHY("BRANDINGM_00012",
                 "Error while clearing branding preference resolver cache hierarchy for tenant: %s."),
+        ERROR_CODE_APPLICATION_NOT_FOUND("BRANDINGM_00013",
+                "There is no application with the name : %s , in the organization: %s."),
         ERROR_CODE_ERROR_VALIDATING_BRANDING_PREFERENCE("BRANDINGM_00021",
                 "Error while validating branding preference configurations for the organization: %s."),
         // Error messages related to custom text configurations.
@@ -96,10 +98,6 @@ public class BrandingPreferenceMgtConstants {
                 "Unable to bulk delete custom text preferences for tenant: %s."),
         ERROR_CODE_ERROR_CLEARING_CUSTOM_TEXT_PREFERENCE_RESOLVER_CACHE_HIERARCHY("BRANDINGM_00031",
                 "Error while clearing custom text preference resolver cache hierarchy for tenant: %s.");
-        ERROR_CODE_ERROR_VALIDATING_BRANDING_PREFERENCE("BRANDINGM_00012",
-                "Error while validating branding preference configurations for the organization: %s."),
-        ERROR_CODE_APPLICATION_NOT_FOUND("BRANDINGM_00013",
-                "There is no application with the name : %s , in the organization: %s.");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/constant/BrandingPreferenceMgtConstants.java
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/constant/BrandingPreferenceMgtConstants.java
@@ -24,6 +24,7 @@ package org.wso2.carbon.identity.branding.preference.management.core.constant;
 public class BrandingPreferenceMgtConstants {
 
     public static final String BRANDING_RESOURCE_TYPE = "BRANDING_PREFERENCES";
+    public static final String APPLICATION_BRANDING_RESOURCE_TYPE = "APPLICATION_BRANDING_PREFERENCES";
     public static final String ORGANIZATION_TYPE = "ORG";
     public static final String APPLICATION_TYPE = "APP";
     public static final String CUSTOM_TYPE = "CUSTOM";
@@ -67,7 +68,9 @@ public class BrandingPreferenceMgtConstants {
         ERROR_CODE_NOT_ALLOWED_BRANDING_PREFERENCE("BRANDINGM_00011",
                 "Requested branding preference configuration: %s is not allowed for the organization."),
         ERROR_CODE_ERROR_VALIDATING_BRANDING_PREFERENCE("BRANDINGM_00012",
-                "Error while validating branding preference configurations for the organization: %s.");
+                "Error while validating branding preference configurations for the organization: %s."),
+        ERROR_CODE_APPLICATION_NOT_FOUND("BRANDINGM_00013",
+                "There is no application with the name : %s , in the organization: %s.");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.branding.preference.management.core/src/test/java/org/wso2/carbon/identity/branding/preference/management/core/BrandingPreferenceManagerImplTest.java
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/src/test/java/org/wso2/carbon/identity/branding/preference/management/core/BrandingPreferenceManagerImplTest.java
@@ -330,9 +330,8 @@ public class BrandingPreferenceManagerImplTest {
         brandingPreferenceManagerImpl.addBrandingPreference(inputBP);
 
         //  Retrieving added branding preference.
-        BrandingPreference retrievedBP =
-                brandingPreferenceManagerImpl.resolveApplicationBrandingPreference(inputBP.getType(), inputBP.getName(),
-                        inputBP.getLocale());
+        BrandingPreference retrievedBP = brandingPreferenceManagerImpl.resolveApplicationBrandingPreference
+                (inputBP.getName(), inputBP.getLocale());
         Assert.assertEquals(retrievedBP.getPreference(), inputBP.getPreference());
         Assert.assertEquals(retrievedBP.getName(), inputBP.getName());
         Assert.assertEquals(retrievedBP.getType(), inputBP.getType());

--- a/components/org.wso2.carbon.identity.branding.preference.management.core/src/test/resources/dbscripts/config/h2.sql
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/src/test/resources/dbscripts/config/h2.sql
@@ -64,4 +64,5 @@ INSERT INTO IDN_CONFIG_TYPE (ID, NAME, DESCRIPTION) VALUES
 ('3c4ac3d0-5903-4e3d-aaca-38df65b33bfd', 'APPLICATION_TEMPLATE', 'Template type to uniquely identify Application templates'),
 ('8ec6dbf1-218a-49bf-bc34-0d2db52d151c', 'CORS_CONFIGURATION', 'A resource type to keep the tenant CORS configurations'),
 ('669b99ca-cdb0-44a6-8cae-babed3b585df', 'Publisher', 'A resource type to keep the event publisher configurations'),
-('73f6d9ca-62f4-4566-bab9-2a930ae51ba8', 'BRANDING_PREFERENCES', 'A resource type to keep the tenant branding preferences');
+('73f6d9ca-62f4-4566-bab9-2a930ae51ba8', 'BRANDING_PREFERENCES', 'A resource type to keep the tenant branding preferences'),
+('8469a176-3e6c-438a-ba01-71e9077072fa', 'APPLICATION_BRANDING_PREFERENCES', 'A resource type to keep the application branding preferences');


### PR DESCRIPTION
## Purpose
> Improve branding BE to store application wise branding preferences.

## Goals
> Provide application branding capability

## Approach
> Use a new resource type `APPLICATION_BRANDING_PREFERENCES` and store application branding preferences in a similar way to organization branding preferences.

## Automation tests
 - Unit tests 
   > 0.46

## Related PRs
- https://github.com/wso2/identity-api-server/pull/454
- https://github.com/wso2/carbon-identity-framework/pull/4617
- https://github.com/wso2/carbon-identity-framework/pull/4616

