### PR TITLE
Improve custom text api to support both locale code formats like en-US & en_US

### DIFF
--- a/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/BrandingPreferenceManagerImpl.java
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/BrandingPreferenceManagerImpl.java
@@ -78,6 +78,7 @@ import static org.wso2.carbon.identity.branding.preference.management.core.const
 import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.RESOURCE_NAME_SEPARATOR;
 import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.RESOURCE_NOT_EXISTS_ERROR_CODE;
 import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.TENANT_DOMAIN;
+import static org.wso2.carbon.identity.branding.preference.management.core.util.BrandingPreferenceMgtUtils.getFormattedLocale;
 import static org.wso2.carbon.identity.branding.preference.management.core.util.BrandingPreferenceMgtUtils.handleClientException;
 import static org.wso2.carbon.identity.branding.preference.management.core.util.BrandingPreferenceMgtUtils.handleServerException;
 
@@ -511,7 +512,8 @@ public class BrandingPreferenceManagerImpl implements BrandingPreferenceManager 
      */
     private String getResourceNameForCustomText(String screen, String locale) {
 
-        return StringUtils.upperCase(screen) + RESOURCE_NAME_SEPARATOR + StringUtils.lowerCase(locale);
+        String formattedLocale = getFormattedLocale(locale);
+        return StringUtils.upperCase(screen) + RESOURCE_NAME_SEPARATOR + StringUtils.lowerCase(formattedLocale);
     }
 
     /**

--- a/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/constant/BrandingPreferenceMgtConstants.java
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/constant/BrandingPreferenceMgtConstants.java
@@ -30,6 +30,7 @@ public class BrandingPreferenceMgtConstants {
     public static final String CUSTOM_TYPE = "CUSTOM";
     public static final String DEFAULT_LOCALE = "en-US";
     public static final String RESOURCE_NAME_SEPARATOR = "_";
+    public static final String LOCAL_CODE_SEPARATOR = "-";
     public static final String PRE_ADD_BRANDING_PREFERENCE = "PRE_ADD_BRANDING_PREFERENCE";
     public static final String PRE_UPDATE_BRANDING_PREFERENCE = "PRE_UPDATE_BRANDING_PREFERENCE";
     public static final String BRANDING_PREFERENCE = "branding-preference";

--- a/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/util/BrandingPreferenceMgtUtils.java
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/util/BrandingPreferenceMgtUtils.java
@@ -27,6 +27,9 @@ import org.wso2.carbon.identity.branding.preference.management.core.constant.Bra
 import org.wso2.carbon.identity.branding.preference.management.core.exception.BrandingPreferenceMgtClientException;
 import org.wso2.carbon.identity.branding.preference.management.core.exception.BrandingPreferenceMgtServerException;
 
+import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.LOCAL_CODE_SEPARATOR;
+import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.RESOURCE_NAME_SEPARATOR;
+
 /**
  * Util class for branding preference management.
  */
@@ -109,6 +112,21 @@ public class BrandingPreferenceMgtUtils {
 
         String message = populateMessageWithData(error);
         return new BrandingPreferenceMgtServerException(message, error.getCode(), e);
+    }
+
+    /**
+     * Replace '_' with '-' in the locale code for support both the locale code formats like en-US & en_US.
+     *
+     * @param locale Locale code.
+     * @return Formatted locale code.
+     */
+    public static String getFormattedLocale(String locale) {
+
+        String formattedLocale = locale;
+        if (StringUtils.isNotBlank(locale)) {
+            formattedLocale = locale.replace(RESOURCE_NAME_SEPARATOR, LOCAL_CODE_SEPARATOR);
+        }
+        return formattedLocale;
     }
 
     private static String populateMessageWithData(BrandingPreferenceMgtConstants.ErrorMessages error, String... data) {

--- a/components/org.wso2.carbon.identity.branding.preference.resolver/src/main/java/org/wso2/carbon/identity/branding/preference/resolver/UIBrandingPreferenceResolverImpl.java
+++ b/components/org.wso2.carbon.identity.branding.preference.resolver/src/main/java/org/wso2/carbon/identity/branding/preference/resolver/UIBrandingPreferenceResolverImpl.java
@@ -62,6 +62,7 @@ import static org.wso2.carbon.identity.branding.preference.management.core.const
 import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.ORGANIZATION_TYPE;
 import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.RESOURCE_NAME_SEPARATOR;
 import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.RESOURCE_NOT_EXISTS_ERROR_CODE;
+import static org.wso2.carbon.identity.branding.preference.management.core.util.BrandingPreferenceMgtUtils.getFormattedLocale;
 import static org.wso2.carbon.identity.branding.preference.management.core.util.BrandingPreferenceMgtUtils.handleClientException;
 import static org.wso2.carbon.identity.branding.preference.management.core.util.BrandingPreferenceMgtUtils.handleServerException;
 
@@ -468,6 +469,7 @@ public class UIBrandingPreferenceResolverImpl implements UIBrandingPreferenceRes
      */
     private String getResourceNameForCustomText(String screen, String locale) {
 
-        return StringUtils.upperCase(screen) + RESOURCE_NAME_SEPARATOR + StringUtils.lowerCase(locale);
+        String formattedLocale = getFormattedLocale(locale);
+        return StringUtils.upperCase(screen) + RESOURCE_NAME_SEPARATOR + StringUtils.lowerCase(formattedLocale);
     }
 }


### PR DESCRIPTION
## Purpose
Improve custom text api to support both locale code formats like en-US & en_US

## Related PRs
- https://github.com/wso2-extensions/identity-branding-preference-management/pull/14
- https://github.com/wso2-extensions/identity-branding-preference-management/pull/16