### PR TITLE
Introduce a method to delete all the custom text preferences configured in an organization

### DIFF
--- a/components/org.wso2.carbon.identity.branding.preference.management.core/pom.xml
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/pom.xml
@@ -204,7 +204,7 @@
                                         <limit implementation="org.jacoco.report.check.Limit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.46</minimum>
+                                            <minimum>0.45</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/BrandingPreferenceManager.java
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/BrandingPreferenceManager.java
@@ -154,4 +154,13 @@ public interface BrandingPreferenceManager {
         throw new NotImplementedException("This functionality is not implemented.");
     }
 
+    /**
+     * This API is used to delete all the custom text preferences configured in an organization.
+     *
+     * @throws BrandingPreferenceMgtException if any error occurred.
+     */
+    default void deleteAllCustomText() throws BrandingPreferenceMgtException {
+
+        throw new NotImplementedException("This functionality is not implemented.");
+    }
 }

--- a/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/BrandingPreferenceManagerImpl.java
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/BrandingPreferenceManagerImpl.java
@@ -365,6 +365,7 @@ public class BrandingPreferenceManagerImpl implements BrandingPreferenceManager 
         }
     }
 
+    @Override
     public void deleteAllCustomText() throws BrandingPreferenceMgtException {
 
         String tenantDomain = getTenantDomain();

--- a/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/BrandingPreferenceManagerImpl.java
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/BrandingPreferenceManagerImpl.java
@@ -59,6 +59,7 @@ import static org.wso2.carbon.identity.branding.preference.management.core.const
 import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.ErrorMessages.ERROR_CODE_ERROR_ADDING_CUSTOM_TEXT_PREFERENCE;
 import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.ErrorMessages.ERROR_CODE_ERROR_BUILDING_BRANDING_PREFERENCE;
 import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.ErrorMessages.ERROR_CODE_ERROR_BUILDING_CUSTOM_TEXT_PREFERENCE;
+import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.ErrorMessages.ERROR_CODE_ERROR_BULK_DELETING_CUSTOM_TEXT_PREFERENCES;
 import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.ErrorMessages.ERROR_CODE_ERROR_CHECKING_BRANDING_PREFERENCE_EXISTS;
 import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.ErrorMessages.ERROR_CODE_ERROR_DELETING_BRANDING_PREFERENCE;
 import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.ErrorMessages.ERROR_CODE_ERROR_DELETING_CUSTOM_TEXT_PREFERENCE;
@@ -74,6 +75,7 @@ import static org.wso2.carbon.identity.branding.preference.management.core.const
 import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.OLD_BRANDING_PREFERENCE;
 import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.PRE_ADD_BRANDING_PREFERENCE;
 import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.PRE_UPDATE_BRANDING_PREFERENCE;
+import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.RESOURCES_NOT_EXISTS_ERROR_CODE;
 import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.RESOURCE_ALREADY_EXISTS_ERROR_CODE;
 import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.RESOURCE_NAME_SEPARATOR;
 import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.RESOURCE_NOT_EXISTS_ERROR_CODE;
@@ -360,6 +362,25 @@ public class BrandingPreferenceManagerImpl implements BrandingPreferenceManager 
         }
         if (LOG.isDebugEnabled()) {
             LOG.debug("Custom text preference for tenant: " + tenantDomain + " deleted successfully.");
+        }
+    }
+
+    public void deleteAllCustomText() throws BrandingPreferenceMgtException {
+
+        String tenantDomain = getTenantDomain();
+        try {
+            getConfigurationManager().deleteResourcesByType(CUSTOM_TEXT_RESOURCE_TYPE);
+        } catch (ConfigurationManagementException e) {
+            if (RESOURCES_NOT_EXISTS_ERROR_CODE.equals(e.getErrorCode())) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Can not find a custom text preferences for tenant: " + tenantDomain, e);
+                }
+                throw handleClientException(ERROR_CODE_CUSTOM_TEXT_PREFERENCE_NOT_EXISTS, tenantDomain);
+            }
+            throw handleServerException(ERROR_CODE_ERROR_BULK_DELETING_CUSTOM_TEXT_PREFERENCES, tenantDomain);
+        }
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Custom text preferences for tenant: " + tenantDomain + " deleted successfully.");
         }
     }
 

--- a/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/constant/BrandingPreferenceMgtConstants.java
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/constant/BrandingPreferenceMgtConstants.java
@@ -38,6 +38,7 @@ public class BrandingPreferenceMgtConstants {
     public static final String TENANT_DOMAIN = "tenant-domain";
 
     public static final String RESOURCE_NOT_EXISTS_ERROR_CODE = "CONFIGM_00017";
+    public static final String RESOURCES_NOT_EXISTS_ERROR_CODE = "CONFIGM_00020";
     public static final String RESOURCE_ALREADY_EXISTS_ERROR_CODE = "CONFIGM_00013";
 
     /**
@@ -86,7 +87,9 @@ public class BrandingPreferenceMgtConstants {
         ERROR_CODE_ERROR_UPDATING_CUSTOM_TEXT_PREFERENCE("BRANDINGM_00028",
                 "Unable to update custom text preference configurations."),
         ERROR_CODE_ERROR_BUILDING_CUSTOM_TEXT_PREFERENCE("BRANDINGM_00029",
-                "Unable to build custom text preference from custom text configurations for tenant: %s.");
+                "Unable to build custom text preference from custom text configurations for tenant: %s."),
+        ERROR_CODE_ERROR_BULK_DELETING_CUSTOM_TEXT_PREFERENCES("BRANDINGM_00030",
+                "Unable to bulk delete custom text preferences for tenant: %s.");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.branding.preference.management.core/src/test/java/org/wso2/carbon/identity/branding/preference/management/core/BrandingPreferenceManagerImplTest.java
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/src/test/java/org/wso2/carbon/identity/branding/preference/management/core/BrandingPreferenceManagerImplTest.java
@@ -618,6 +618,64 @@ public class BrandingPreferenceManagerImplTest {
                 .deleteCustomText(ORGANIZATION_TYPE, SUPER_TENANT_DOMAIN_NAME, LOGIN_SCREEN, DEFAULT_LOCALE));
     }
 
+    @DataProvider(name = "multipleCustomTextDataProvider")
+    public Object[][] multipleCustomTextDataProvider() throws Exception {
+
+        CustomText customText1 = new CustomText();
+        customText1.setType(ORGANIZATION_TYPE);
+        customText1.setName(SAMPLE_TENANT_DOMAIN_NAME_ABC);
+        customText1.setScreen(LOGIN_SCREEN);
+        customText1.setLocale(DEFAULT_LOCALE);
+        customText1.setPreference(getPreferenceFromFile("sample-text-customization-1.json"));
+
+        CustomText customText2 = new CustomText();
+        customText2.setType(ORGANIZATION_TYPE);
+        customText2.setName(SAMPLE_TENANT_DOMAIN_NAME_ABC);
+        customText2.setScreen(LOGIN_SCREEN);
+        customText2.setLocale(FRENCH_LOCALE);
+        customText2.setPreference(getPreferenceFromFile("sample-text-customization-2.json"));
+
+        return new Object[][]{
+                {customText1, customText2, SAMPLE_TENANT_DOMAIN_NAME_ABC, SUPER_TENANT_ID},
+        };
+    }
+
+    @Test(dataProvider = "multipleCustomTextDataProvider")
+    public void testDeleteAllCustomText(Object customText1, Object customText2, String tenantDomain, int tenantId)
+            throws Exception {
+
+        setCarbonContextForTenant(tenantDomain, tenantId);
+        CustomText inputCT1 = (CustomText) customText1;
+        CustomText inputCT2 = (CustomText) customText2;
+
+        // Adding new custom text preference.
+        brandingPreferenceManagerImpl.addCustomText(inputCT1);
+        brandingPreferenceManagerImpl.addCustomText(inputCT2);
+
+        // Retrieving added custom text preference.
+        CustomText retrievedCT1 = brandingPreferenceManagerImpl.getCustomText
+                (inputCT1.getType(), inputCT1.getName(), inputCT1.getScreen(), inputCT1.getLocale());
+        Assert.assertEquals(retrievedCT1.getPreference(), inputCT1.getPreference());
+        Assert.assertEquals(retrievedCT1.getName(), inputCT1.getName());
+        Assert.assertEquals(retrievedCT1.getType(), inputCT1.getType());
+        Assert.assertEquals(retrievedCT1.getLocale(), inputCT1.getLocale());
+
+        CustomText retrievedCT2 = brandingPreferenceManagerImpl.getCustomText
+                (inputCT2.getType(), inputCT2.getName(), inputCT2.getScreen(), inputCT2.getLocale());
+        Assert.assertEquals(retrievedCT2.getPreference(), inputCT2.getPreference());
+        Assert.assertEquals(retrievedCT2.getName(), inputCT2.getName());
+        Assert.assertEquals(retrievedCT2.getType(), inputCT2.getType());
+        Assert.assertEquals(retrievedCT2.getLocale(), inputCT2.getLocale());
+
+        // Bulk Deleting added custom text preferences.
+        brandingPreferenceManagerImpl.deleteAllCustomText();
+
+        assertThrows(BrandingPreferenceMgtClientException.class, () -> brandingPreferenceManagerImpl
+                .getCustomText(inputCT1.getType(), inputCT1.getName(), inputCT1.getScreen(), inputCT1.getLocale()));
+        assertThrows(BrandingPreferenceMgtClientException.class, () -> brandingPreferenceManagerImpl
+                .getCustomText(inputCT2.getType(), inputCT2.getName(), inputCT2.getScreen(), inputCT2.getLocale()));
+    }
+
     private void setCarbonContextForTenant(String tenantDomain, int tenantId) throws UserStoreException {
 
         PrivilegedCarbonContext.startTenantFlow();

--- a/pom.xml
+++ b/pom.xml
@@ -355,7 +355,7 @@
         <pax.logging.api.version>1.10.1</pax.logging.api.version>
 
         <!-- Carbon identity framework version -->
-        <carbon.identity.framework.version>5.20.267</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.389-SNAPSHOT</carbon.identity.framework.version>
         <carbon.identity.package.import.version.range>[5.20.0, 7.0.0)</carbon.identity.package.import.version.range>
 
         <!-- Org management dependency versions-->

--- a/pom.xml
+++ b/pom.xml
@@ -355,7 +355,7 @@
         <pax.logging.api.version>1.10.1</pax.logging.api.version>
 
         <!-- Carbon identity framework version -->
-        <carbon.identity.framework.version>5.25.389-SNAPSHOT</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.437</carbon.identity.framework.version>
         <carbon.identity.package.import.version.range>[5.20.0, 7.0.0)</carbon.identity.package.import.version.range>
 
         <!-- Org management dependency versions-->


### PR DESCRIPTION
## Purpose
- Introduce a new method to delete all the custom text preferences configured in an organization

## TODO

- [ ] Bump Frmaework Version

## Related PRs

- https://github.com/wso2/carbon-identity-framework/pull/5030