### PR TITLE
Add null check for the child tenant domains

### DIFF
--- a/components/org.wso2.carbon.identity.branding.preference.resolver/src/main/java/org/wso2/carbon/identity/branding/preference/resolver/UIBrandingPreferenceResolverImpl.java
+++ b/components/org.wso2.carbon.identity.branding.preference.resolver/src/main/java/org/wso2/carbon/identity/branding/preference/resolver/UIBrandingPreferenceResolverImpl.java
@@ -226,15 +226,17 @@ public class UIBrandingPreferenceResolverImpl implements UIBrandingPreferenceRes
 
             try {
                 String childTenantDomain = organizationManager.resolveTenantDomain(childOrganizationId);
-                BrandedOrgCacheEntry valueFromCache =
-                        brandedOrgCache.getValueFromCache(brandedOrgCacheKey, childTenantDomain);
-                if (valueFromCache != null) {
-                    // If cache exists, clear the cache
-                    brandedOrgCache.clearCacheEntry(brandedOrgCacheKey, childTenantDomain);
-                }
+                if (StringUtils.isNotBlank(childTenantDomain)) {
+                    BrandedOrgCacheEntry valueFromCache =
+                            brandedOrgCache.getValueFromCache(brandedOrgCacheKey, childTenantDomain);
+                    if (valueFromCache != null) {
+                        // If cache exists, clear the cache
+                        brandedOrgCache.clearCacheEntry(brandedOrgCacheKey, childTenantDomain);
+                    }
 
-                // Add Ids of all child organizations of the current (child) organization
-                childOrganizationIds.addAll(organizationManager.getChildOrganizationsIds(childOrganizationId));
+                    // Add Ids of all child organizations of the current (child) organization
+                    childOrganizationIds.addAll(organizationManager.getChildOrganizationsIds(childOrganizationId));
+                }
             } catch (OrganizationManagementException e) {
                 throw handleServerException(ERROR_CODE_ERROR_CLEARING_BRANDING_PREFERENCE_RESOLVER_CACHE_HIERARCHY,
                         currentTenantDomain);


### PR DESCRIPTION
## Purpose
> It was identified that due to an issue in tenant deletion, stale org data remains in UM_ORG table. Due to this, the `childTenantDomain` value set at [1] becomes null, which causes an exception to be thrown. As a resolution, in the PR a null check is introduced so that such corrupted orgs will be skipped from cache deletion step.

[1] https://github.com/wso2-extensions/identity-branding-preference-management/blob/c3cef6944aa26bd9357f85464d19749758380ca7/components/org.wso2.carbon.identity.branding.preference.resolver/src/main/java/org/wso2/carbon/identity/branding/preference/resolver/UIBrandingPreferenceResolverImpl.java#L228 

## Related Issues
- https://github.com/wso2-enterprise/asgardeo-product/issues/22269