### PR TITLE
Implement Functionality to Resolve Branding Preferences using only Published Branding Preferences

### DIFF
--- a/components/org.wso2.carbon.identity.branding.preference.management.core/pom.xml
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.branding.preference.management</groupId>
         <artifactId>identity-branding-preference-management</artifactId>
-        <version>1.1.14</version>
+        <version>1.1.15-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/BrandingPreferenceManager.java
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/BrandingPreferenceManager.java
@@ -58,9 +58,29 @@ public interface BrandingPreferenceManager {
      * @param locale Language preference of the branding.
      * @return The resolved branding preference. If not exists return the default branding preference.
      * @throws BrandingPreferenceMgtException if any error occurred.
+     * @deprecated Use {@link #resolveBrandingPreference(String, String, String, boolean)}} instead.
      */
+    @Deprecated
     BrandingPreference resolveBrandingPreference(String type, String name, String locale)
             throws BrandingPreferenceMgtException;
+
+    /**
+     * This service method is used to retrieve resolved branding preferences.
+     *
+     * @param type                Type of the branding preference.
+     * @param name                Name of the tenant/application.
+     * @param locale              Language preference of the branding.
+     * @param restrictToPublished Whether to resolve using only published branding preferences only.
+     * @return The resolved branding preference. If not exists return the default branding preference.
+     * @throws BrandingPreferenceMgtException if any error occurred.
+     */
+    default BrandingPreference resolveBrandingPreference(String type, String name, String locale,
+                                                         boolean restrictToPublished)
+            throws BrandingPreferenceMgtException {
+
+        throw new NotImplementedException(
+                "resolveApplicationBrandingPreference method is not implemented in " + this.getClass().getName());
+    }
 
     /**
      * This API is used to retrieve a resolved branding preference for an application.
@@ -69,7 +89,7 @@ public interface BrandingPreferenceManager {
      * @param locale     Language preference of the branding.
      * @return The resolved branding preference. If not exists return the default branding preference.
      * @throws BrandingPreferenceMgtException if any error occurred.
-     * @deprecated Use {@link #resolveBrandingPreference(String, String, String)}} instead.
+     * @deprecated Use {@link #resolveBrandingPreference(String, String, String, boolean)}} instead.
      */
     @Deprecated
     default BrandingPreference resolveApplicationBrandingPreference(String identifier, String locale)

--- a/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/UIBrandingPreferenceResolver.java
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/UIBrandingPreferenceResolver.java
@@ -36,8 +36,27 @@ public interface UIBrandingPreferenceResolver {
      * @param locale Language preference of the branding.
      * @return The requested branding preference. If not exists return the default branding preference.
      * @throws BrandingPreferenceMgtException if any error occurred.
+     * @deprecated Use {@link #resolveBranding(String, String, String, boolean)}} instead.
      */
+    @Deprecated
     BrandingPreference resolveBranding(String type, String name, String locale) throws BrandingPreferenceMgtException;
+
+    /**
+     * This method is used to retrieve a resolved branding preference.
+     *
+     * @param type                Type of the branding preference.
+     * @param name                Name of the tenant/application.
+     * @param locale              Language preference of the branding.
+     * @param restrictToPublished Whether to resolve using only published branding preferences.
+     * @return The requested branding preference. If not exists return the default branding preference.
+     * @throws BrandingPreferenceMgtException if any error occurred while resolving branding preferences.
+     */
+    default BrandingPreference resolveBranding(String type, String name, String locale, boolean restrictToPublished)
+            throws BrandingPreferenceMgtException {
+
+        throw new NotImplementedException(
+                "resolveBranding method is not implemented in " + this.getClass().getName());
+    }
 
     /**
      * This method is used to clear the branding preference resolver caches, down

--- a/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/util/BrandingPreferenceMgtUtils.java
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/util/BrandingPreferenceMgtUtils.java
@@ -26,7 +26,12 @@ import org.json.JSONObject;
 import org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants;
 import org.wso2.carbon.identity.branding.preference.management.core.exception.BrandingPreferenceMgtClientException;
 import org.wso2.carbon.identity.branding.preference.management.core.exception.BrandingPreferenceMgtServerException;
+import org.wso2.carbon.identity.branding.preference.management.core.model.BrandingPreference;
 
+import java.util.LinkedHashMap;
+
+import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.CONFIGS;
+import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.IS_BRANDING_ENABLED;
 import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.LOCAL_CODE_SEPARATOR;
 import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.RESOURCE_NAME_SEPARATOR;
 
@@ -127,6 +132,21 @@ public class BrandingPreferenceMgtUtils {
             formattedLocale = locale.replace(RESOURCE_NAME_SEPARATOR, LOCAL_CODE_SEPARATOR);
         }
         return formattedLocale;
+    }
+
+    /**
+     * Check whether the given branding preference is published or not.
+     *
+     * @param brandingPreference Branding preference that needs to be checked.
+     * @return True if the branding preference is published.
+     */
+    public static boolean isBrandingPublished(BrandingPreference brandingPreference) {
+
+        JSONObject preferences = new JSONObject((LinkedHashMap) brandingPreference.getPreference());
+
+        // If configs.isBrandingEnabled is not found in preferences, it is assumed that branding is enabled by default.
+        return !preferences.has(CONFIGS) ||
+                preferences.getJSONObject(CONFIGS).optBoolean(IS_BRANDING_ENABLED, true);
     }
 
     private static String populateMessageWithData(BrandingPreferenceMgtConstants.ErrorMessages error, String... data) {

--- a/components/org.wso2.carbon.identity.branding.preference.management.core/src/test/java/org/wso2/carbon/identity/branding/preference/management/core/BrandingPreferenceManagerImplTest.java
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/src/test/java/org/wso2/carbon/identity/branding/preference/management/core/BrandingPreferenceManagerImplTest.java
@@ -264,11 +264,12 @@ public class BrandingPreferenceManagerImplTest {
 
         setCarbonContextForTenant(tenantDomain, tenantId);
         BrandingPreference inputBP = (BrandingPreference) brandingPreference;
-        when(resolver.resolveBranding(inputBP.getType(), inputBP.getName(), inputBP.getLocale())).thenReturn(inputBP);
+        when(resolver.resolveBranding(inputBP.getType(), inputBP.getName(), inputBP.getLocale(), false))
+                .thenReturn(inputBP);
 
         BrandingPreference retrievedBP =
                 brandingPreferenceManagerImpl.resolveBrandingPreference(inputBP.getType(), inputBP.getName(),
-                        inputBP.getLocale());
+                        inputBP.getLocale(), false);
         Assert.assertEquals(retrievedBP.getPreference(), inputBP.getPreference());
         Assert.assertEquals(retrievedBP.getName(), inputBP.getName());
         Assert.assertEquals(retrievedBP.getType(), inputBP.getType());
@@ -281,11 +282,12 @@ public class BrandingPreferenceManagerImplTest {
 
         setCarbonContextForTenant(tenantDomain, tenantId);
         BrandingPreference inputBP = (BrandingPreference) brandingPreference;
-        when(resolver.resolveBranding(inputBP.getType(), inputBP.getName(), inputBP.getLocale())).thenReturn(inputBP);
+        when(resolver.resolveBranding(inputBP.getType(), inputBP.getName(), inputBP.getLocale(), false))
+                .thenReturn(inputBP);
 
         //  Retrieving added branding preference.
         BrandingPreference retrievedBP = brandingPreferenceManagerImpl.resolveBrandingPreference
-                (inputBP.getType(), inputBP.getName(), inputBP.getLocale());
+                (inputBP.getType(), inputBP.getName(), inputBP.getLocale(), false);
         Assert.assertEquals(retrievedBP.getPreference(), inputBP.getPreference());
         Assert.assertEquals(retrievedBP.getName(), inputBP.getName());
         Assert.assertEquals(retrievedBP.getType(), inputBP.getType());

--- a/components/org.wso2.carbon.identity.branding.preference.management.core/src/test/java/org/wso2/carbon/identity/branding/preference/management/core/util/BrandingPreferenceMgtUtilsTest.java
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/src/test/java/org/wso2/carbon/identity/branding/preference/management/core/util/BrandingPreferenceMgtUtilsTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.branding.preference.management.core.util;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.branding.preference.management.core.model.BrandingPreference;
+
+import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.DEFAULT_LOCALE;
+import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.ORGANIZATION_TYPE;
+import static org.wso2.carbon.identity.branding.preference.management.core.util.TestUtils.getPreferenceFromFile;
+
+/**
+ * Unit tests for BrandingPreferenceMgtUtils.
+ */
+public class BrandingPreferenceMgtUtilsTest {
+
+    public static final String SUPER_TENANT_DOMAIN_NAME = "carbon.super";
+
+    @DataProvider(name = "publishedBrandingPreferenceDataProvider")
+    public Object[][] publishedBrandingPreferenceDataProvider() throws Exception {
+
+        return new Object[][]{
+                {"sample-preference-1.json"},
+                {"sample-preference-without-isBrandingEnabled-config.json"},
+                {"sample-preference-without-configs.json"},
+        };
+    }
+
+    @Test(dataProvider = "publishedBrandingPreferenceDataProvider")
+    public void testIsPublishedBranding(String preferenceFile) throws Exception {
+
+        BrandingPreference brandingPreference = new BrandingPreference();
+        brandingPreference.setType(ORGANIZATION_TYPE);
+        brandingPreference.setName(SUPER_TENANT_DOMAIN_NAME);
+        brandingPreference.setLocale(DEFAULT_LOCALE);
+        brandingPreference.setPreference(getPreferenceFromFile(preferenceFile));
+
+        boolean isBrandingPublished = BrandingPreferenceMgtUtils.isBrandingPublished(brandingPreference);
+        Assert.assertTrue(isBrandingPublished);
+    }
+
+    @Test
+    public void testIsPublishedBrandingWithUnpublishedPreferences() throws Exception {
+
+        BrandingPreference brandingPreference = new BrandingPreference();
+        brandingPreference.setType(ORGANIZATION_TYPE);
+        brandingPreference.setName(SUPER_TENANT_DOMAIN_NAME);
+        brandingPreference.setLocale(DEFAULT_LOCALE);
+        brandingPreference.setPreference(getPreferenceFromFile("sample-unpublished-preference.json"));
+
+        boolean isBrandingPublished = BrandingPreferenceMgtUtils.isBrandingPublished(brandingPreference);
+        Assert.assertFalse(isBrandingPublished);
+    }
+}

--- a/components/org.wso2.carbon.identity.branding.preference.management.core/src/test/resources/samples/sample-preference-without-configs.json
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/src/test/resources/samples/sample-preference-without-configs.json
@@ -1,0 +1,25 @@
+{
+  "organizationDetails": {
+    "displayName": "Coala Sports",
+    "siteTitle": "Login - Coala Sports",
+    "copyrightText": "© 2021 Coala Sports Inc.",
+    "supportEmail": "support@coalasports.com"
+  },
+  "colors": {
+    "primary": "#FF0000"
+  },
+  "images": {
+    "logo": {
+      "imgURL": "https://image/upload/q_auto,f_auto/kentcdodds.com/illustrations/kody_profile_white",
+      "altText": "Coala Sports Logo"
+    },
+    "favicon": {
+      "imgURL": "https://favicons/favicon-16x16.png"
+    }
+  },
+  "urls": {
+    "privacyPolicyURL": "https://coalasports.com/privacy-policy",
+    "termsOfUseURL": "https://coalasports.com/terms-of-service/",
+    "cookiePolicyURL": "https://coalasports.com/privacy-policy/#cookie-policy"
+  }
+}

--- a/components/org.wso2.carbon.identity.branding.preference.management.core/src/test/resources/samples/sample-preference-without-isBrandingEnabled-config.json
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/src/test/resources/samples/sample-preference-without-isBrandingEnabled-config.json
@@ -1,0 +1,26 @@
+{
+  "organizationDetails": {
+    "displayName": "Coala Sports",
+    "siteTitle": "Login - Coala Sports",
+    "copyrightText": "© 2021 Coala Sports Inc.",
+    "supportEmail": "support@coalasports.com"
+  },
+  "colors": {
+    "primary": "#FF0000"
+  },
+  "images": {
+    "logo": {
+      "imgURL": "https://image/upload/q_auto,f_auto/kentcdodds.com/illustrations/kody_profile_white",
+      "altText": "Coala Sports Logo"
+    },
+    "favicon": {
+      "imgURL": "https://favicons/favicon-16x16.png"
+    }
+  },
+  "urls": {
+    "privacyPolicyURL": "https://coalasports.com/privacy-policy",
+    "termsOfUseURL": "https://coalasports.com/terms-of-service/",
+    "cookiePolicyURL": "https://coalasports.com/privacy-policy/#cookie-policy"
+  },
+  "configs": {}
+}

--- a/components/org.wso2.carbon.identity.branding.preference.management.core/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/src/test/resources/testng.xml
@@ -1,7 +1,7 @@
 <!--
-  ~ Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+  ~ Copyright (c) 2022-2024, WSO2 LLC. (http://www.wso2.com).
   ~
-  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except
   ~ in compliance with the License.
   ~ You may obtain a copy of the License at
@@ -23,6 +23,7 @@
     <test name="BrandingPreferenceManagementTests" parallel="false">
         <classes>
             <class name="org.wso2.carbon.identity.branding.preference.management.core.BrandingPreferenceManagerImplTest"/>
+            <class name="org.wso2.carbon.identity.branding.preference.management.core.util.BrandingPreferenceMgtUtilsTest"/>
         </classes>
     </test>
 </suite>

--- a/components/org.wso2.carbon.identity.branding.preference.resolver/pom.xml
+++ b/components/org.wso2.carbon.identity.branding.preference.resolver/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.branding.preference.management</groupId>
         <artifactId>identity-branding-preference-management</artifactId>
-        <version>1.1.14</version>
+        <version>1.1.15-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.branding.preference.resolver/src/test/java/org/wso2/carbon/identity/branding/preference/resolver/UIBrandingPreferenceResolverImplTest.java
+++ b/components/org.wso2.carbon.identity.branding.preference.resolver/src/test/java/org/wso2/carbon/identity/branding/preference/resolver/UIBrandingPreferenceResolverImplTest.java
@@ -144,7 +144,7 @@ public class UIBrandingPreferenceResolverImplTest {
                     resourceFileName);
 
             BrandingPreference resolvedBrandingPreference =
-                    brandingPreferenceResolver.resolveBranding(APPLICATION_TYPE, CHILD_APP_ID, DEFAULT_LOCALE);
+                    brandingPreferenceResolver.resolveBranding(APPLICATION_TYPE, CHILD_APP_ID, DEFAULT_LOCALE, false);
 
             Assert.assertEquals(resolvedBrandingPreference.getName(), CHILD_APP_ID);
             Assert.assertEquals(resolvedBrandingPreference.getLocale(), DEFAULT_LOCALE);
@@ -168,7 +168,7 @@ public class UIBrandingPreferenceResolverImplTest {
             mockBrandingPreferenceRetrieval(resourceName, resourceId, BRANDING_RESOURCE_TYPE, resourceFileName);
 
             BrandingPreference resolvedBrandingPreference =
-                    brandingPreferenceResolver.resolveBranding(APPLICATION_TYPE, CHILD_APP_ID, DEFAULT_LOCALE);
+                    brandingPreferenceResolver.resolveBranding(APPLICATION_TYPE, CHILD_APP_ID, DEFAULT_LOCALE, false);
 
             Assert.assertEquals(resolvedBrandingPreference.getName(), CHILD_ORG_ID);
             Assert.assertEquals(resolvedBrandingPreference.getLocale(), DEFAULT_LOCALE);
@@ -197,7 +197,7 @@ public class UIBrandingPreferenceResolverImplTest {
                     resourceFileName);
 
             BrandingPreference resolvedBrandingPreference =
-                    brandingPreferenceResolver.resolveBranding(APPLICATION_TYPE, CHILD_APP_ID, DEFAULT_LOCALE);
+                    brandingPreferenceResolver.resolveBranding(APPLICATION_TYPE, CHILD_APP_ID, DEFAULT_LOCALE, false);
 
             Assert.assertEquals(resolvedBrandingPreference.getName(), PARENT_APP_ID);
             Assert.assertEquals(resolvedBrandingPreference.getLocale(), DEFAULT_LOCALE);
@@ -226,7 +226,7 @@ public class UIBrandingPreferenceResolverImplTest {
             mockBrandingPreferenceRetrieval(resourceName, resourceId, BRANDING_RESOURCE_TYPE, resourceFileName);
 
             BrandingPreference resolvedBrandingPreference =
-                    brandingPreferenceResolver.resolveBranding(APPLICATION_TYPE, CHILD_APP_ID, DEFAULT_LOCALE);
+                    brandingPreferenceResolver.resolveBranding(APPLICATION_TYPE, CHILD_APP_ID, DEFAULT_LOCALE, false);
 
             Assert.assertEquals(resolvedBrandingPreference.getName(), PARENT_ORG_ID);
             Assert.assertEquals(resolvedBrandingPreference.getLocale(), DEFAULT_LOCALE);
@@ -258,7 +258,7 @@ public class UIBrandingPreferenceResolverImplTest {
                     resourceFileName);
 
             BrandingPreference resolvedBrandingPreference =
-                    brandingPreferenceResolver.resolveBranding(APPLICATION_TYPE, CHILD_APP_ID, DEFAULT_LOCALE);
+                    brandingPreferenceResolver.resolveBranding(APPLICATION_TYPE, CHILD_APP_ID, DEFAULT_LOCALE, false);
 
             Assert.assertEquals(resolvedBrandingPreference.getName(), ROOT_APP_ID);
             Assert.assertEquals(resolvedBrandingPreference.getLocale(), DEFAULT_LOCALE);
@@ -281,7 +281,6 @@ public class UIBrandingPreferenceResolverImplTest {
 
             mockAncestorOrgIdAndAppIdRetrieval();
 
-
             when(organizationManager.resolveTenantDomain(ROOT_ORG_ID)).thenReturn(ROOT_TENANT_DOMAIN);
             when(organizationManager.getOrganizationDepthInHierarchy(ROOT_ORG_ID)).thenReturn(0);
 
@@ -291,13 +290,150 @@ public class UIBrandingPreferenceResolverImplTest {
             mockBrandingPreferenceRetrieval(resourceName, resourceId, BRANDING_RESOURCE_TYPE, resourceFileName);
 
             BrandingPreference resolvedBrandingPreference =
-                    brandingPreferenceResolver.resolveBranding(APPLICATION_TYPE, CHILD_APP_ID, DEFAULT_LOCALE);
+                    brandingPreferenceResolver.resolveBranding(APPLICATION_TYPE, CHILD_APP_ID, DEFAULT_LOCALE, false);
 
             Assert.assertEquals(resolvedBrandingPreference.getName(), ROOT_TENANT_DOMAIN);
             Assert.assertEquals(resolvedBrandingPreference.getLocale(), DEFAULT_LOCALE);
             Assert.assertEquals(resolvedBrandingPreference.getType(), ORGANIZATION_TYPE);
             Assert.assertEquals(resolvedBrandingPreference.getPreference(),
                     getPreferenceFromFile("sample-root-org-branding-preference-without-display-name.json"));
+        }
+    }
+
+    @Test
+    public void testResolveAppBrandingRestrictedToPublishedWithPublishedCurrentAppBranding() throws Exception {
+
+        try (MockedStatic<OSGiDataHolder> mockedOSGiDataHolder = mockStatic(OSGiDataHolder.class)) {
+            mockOSGiDataHolder(mockedOSGiDataHolder);
+            setCarbonContextForTenant(CHILD_ORG_ID, CHILD_TENANT_ID, CHILD_ORG_ID);
+
+            String resourceName = CHILD_APP_ID.toLowerCase() + RESOURCE_NAME_SEPARATOR + DEFAULT_LOCALE;
+            String resourceId = "51356f5e-e10b-49f2-87a6-f7f48e164374";
+            String resourceFileName = "sample-child-app-branding-preference.json";
+
+            mockBrandingPreferenceRetrieval(resourceName, resourceId, APPLICATION_BRANDING_RESOURCE_TYPE,
+                    resourceFileName);
+
+            BrandingPreference resolvedBrandingPreference =
+                    brandingPreferenceResolver.resolveBranding(APPLICATION_TYPE, CHILD_APP_ID, DEFAULT_LOCALE, true);
+
+            Assert.assertEquals(resolvedBrandingPreference.getName(), CHILD_APP_ID);
+            Assert.assertEquals(resolvedBrandingPreference.getLocale(), DEFAULT_LOCALE);
+            Assert.assertEquals(resolvedBrandingPreference.getType(), APPLICATION_TYPE);
+            Assert.assertEquals(resolvedBrandingPreference.getPreference(), getPreferenceFromFile(resourceFileName));
+        }
+    }
+
+    @Test
+    public void testResolveAppBrandingRestrictedToPublishedWithUnpublishedCurrentAppBranding() throws Exception {
+
+        try (MockedStatic<OSGiDataHolder> mockedOSGiDataHolder = mockStatic(OSGiDataHolder.class)) {
+            mockOSGiDataHolder(mockedOSGiDataHolder);
+            setCarbonContextForTenant(CHILD_ORG_ID, CHILD_TENANT_ID, CHILD_ORG_ID);
+
+            String resourceName = CHILD_APP_ID.toLowerCase() + RESOURCE_NAME_SEPARATOR + DEFAULT_LOCALE;
+            String resourceId = "51356f5e-e10b-49f2-87a6-f7f48e164374";
+            String resourceFileName = "sample-child-app-unpublished-branding-preference.json";
+
+            mockBrandingPreferenceRetrieval(resourceName, resourceId, APPLICATION_BRANDING_RESOURCE_TYPE,
+                    resourceFileName);
+
+            assertThrows(BrandingPreferenceMgtClientException.class, () -> {
+                BrandingPreference resolvedBrandingPreference =
+                        brandingPreferenceResolver.resolveBranding(APPLICATION_TYPE, CHILD_APP_ID, DEFAULT_LOCALE,
+                                true);
+
+            });
+        }
+    }
+
+    @Test
+    public void testResolveAppBrandingWithUnpublishedCurrentAppBranding() throws Exception {
+
+        try (MockedStatic<OSGiDataHolder> mockedOSGiDataHolder = mockStatic(OSGiDataHolder.class)) {
+            mockOSGiDataHolder(mockedOSGiDataHolder);
+            setCarbonContextForTenant(CHILD_ORG_ID, CHILD_TENANT_ID, CHILD_ORG_ID);
+
+            String resourceName = CHILD_APP_ID.toLowerCase() + RESOURCE_NAME_SEPARATOR + DEFAULT_LOCALE;
+            String resourceId = "51356f5e-e10b-49f2-87a6-f7f48e164374";
+            String resourceFileName = "sample-child-app-unpublished-branding-preference.json";
+
+            mockBrandingPreferenceRetrieval(resourceName, resourceId, APPLICATION_BRANDING_RESOURCE_TYPE,
+                    resourceFileName);
+
+            BrandingPreference resolvedBrandingPreference =
+                    brandingPreferenceResolver.resolveBranding(APPLICATION_TYPE, CHILD_APP_ID, DEFAULT_LOCALE, false);
+
+            /* Even the current app branding is unpublished, resolver should return it
+              since restrictToPublished param is set to false. */
+            Assert.assertEquals(resolvedBrandingPreference.getName(), CHILD_APP_ID);
+            Assert.assertEquals(resolvedBrandingPreference.getLocale(), DEFAULT_LOCALE);
+            Assert.assertEquals(resolvedBrandingPreference.getType(), APPLICATION_TYPE);
+            Assert.assertEquals(resolvedBrandingPreference.getPreference(), getPreferenceFromFile(resourceFileName));
+        }
+    }
+
+    @Test
+    public void testResolveAppBrandingRestrictedToPublishedWithPublishedCurrentOrgBranding() throws Exception {
+
+        try (MockedStatic<OSGiDataHolder> mockedOSGiDataHolder = mockStatic(OSGiDataHolder.class)) {
+            mockOSGiDataHolder(mockedOSGiDataHolder);
+            setCarbonContextForTenant(CHILD_ORG_ID, CHILD_TENANT_ID, CHILD_ORG_ID);
+
+            String appResourceName = CHILD_APP_ID.toLowerCase() + RESOURCE_NAME_SEPARATOR + DEFAULT_LOCALE;
+            String appResourceId = "51356f5e-e10b-49f2-87a6-f7f48e164374";
+            String appResourceFileName = "sample-child-app-unpublished-branding-preference.json";
+
+            // Mock unpublished current app branding.
+            mockBrandingPreferenceRetrieval(appResourceName, appResourceId, APPLICATION_BRANDING_RESOURCE_TYPE,
+                    appResourceFileName);
+
+            String orgResourceName =
+                    String.valueOf(CHILD_TENANT_ID).toLowerCase() + RESOURCE_NAME_SEPARATOR + DEFAULT_LOCALE;
+            String orgResourceId = "61356f5e-e10b-49f2-87a6-f7f48e164374";
+            String orgResourceFileName = "sample-child-org-branding-preference.json";
+
+            // Mock published current org branding.
+            mockBrandingPreferenceRetrieval(orgResourceName, orgResourceId, BRANDING_RESOURCE_TYPE,
+                    orgResourceFileName);
+
+            BrandingPreference resolvedBrandingPreference =
+                    brandingPreferenceResolver.resolveBranding(APPLICATION_TYPE, CHILD_APP_ID, DEFAULT_LOCALE, true);
+
+            // Resolver should return published org branding since restrictToPublished param is set to true.
+            Assert.assertEquals(resolvedBrandingPreference.getName(), CHILD_ORG_ID);
+            Assert.assertEquals(resolvedBrandingPreference.getLocale(), DEFAULT_LOCALE);
+            Assert.assertEquals(resolvedBrandingPreference.getType(), ORGANIZATION_TYPE);
+            Assert.assertEquals(resolvedBrandingPreference.getPreference(), getPreferenceFromFile(orgResourceFileName));
+        }
+    }
+
+    @Test
+    public void testResolveAppBrandingRestrictedToPublishedWithNoPublishedBranding() throws Exception {
+
+        try (MockedStatic<OSGiDataHolder> mockedOSGiDataHolder = mockStatic(OSGiDataHolder.class)) {
+            mockOSGiDataHolder(mockedOSGiDataHolder);
+            setCarbonContextForTenant(CHILD_ORG_ID, CHILD_TENANT_ID, CHILD_ORG_ID);
+            String resourceName =
+                    String.valueOf(ROOT_TENANT_ID).toLowerCase() + RESOURCE_NAME_SEPARATOR + DEFAULT_LOCALE;
+            String resourceId = "11356f5e-e10b-49f2-87a6-f7f48e164374";
+            String resourceFileName = "sample-root-org-unpublished-branding-preference.json";
+
+            mockAncestorOrgIdAndAppIdRetrieval();
+
+            when(organizationManager.resolveTenantDomain(ROOT_ORG_ID)).thenReturn(ROOT_TENANT_DOMAIN);
+            when(organizationManager.getOrganizationDepthInHierarchy(ROOT_ORG_ID)).thenReturn(0);
+
+            when(organizationManager.resolveTenantDomain(PARENT_ORG_ID)).thenReturn(PARENT_ORG_ID);
+            when(organizationManager.getOrganizationDepthInHierarchy(PARENT_ORG_ID)).thenReturn(1);
+
+            mockBrandingPreferenceRetrieval(resourceName, resourceId, BRANDING_RESOURCE_TYPE, resourceFileName);
+
+            assertThrows(BrandingPreferenceMgtClientException.class, () -> {
+                BrandingPreference resolvedBrandingPreference =
+                        brandingPreferenceResolver.resolveBranding(APPLICATION_TYPE, CHILD_APP_ID, DEFAULT_LOCALE,
+                                true);
+            });
         }
     }
 
@@ -318,7 +454,8 @@ public class UIBrandingPreferenceResolverImplTest {
 
             assertThrows(BrandingPreferenceMgtClientException.class, () -> {
                 BrandingPreference resolvedBrandingPreference =
-                        brandingPreferenceResolver.resolveBranding(APPLICATION_TYPE, CHILD_APP_ID, DEFAULT_LOCALE);
+                        brandingPreferenceResolver.resolveBranding(APPLICATION_TYPE, CHILD_APP_ID, DEFAULT_LOCALE,
+                                false);
             });
         }
     }
@@ -342,7 +479,7 @@ public class UIBrandingPreferenceResolverImplTest {
                     resourceFileName);
 
             BrandingPreference resolvedBrandingPreference =
-                    brandingPreferenceResolver.resolveBranding(APPLICATION_TYPE, CHILD_APP_ID, DEFAULT_LOCALE);
+                    brandingPreferenceResolver.resolveBranding(APPLICATION_TYPE, CHILD_APP_ID, DEFAULT_LOCALE, false);
 
             Assert.assertEquals(resolvedBrandingPreference.getName(), PARENT_APP_ID);
             Assert.assertEquals(resolvedBrandingPreference.getLocale(), DEFAULT_LOCALE);
@@ -371,13 +508,156 @@ public class UIBrandingPreferenceResolverImplTest {
             mockBrandingPreferenceRetrieval(resourceName, resourceId, BRANDING_RESOURCE_TYPE, resourceFileName);
 
             BrandingPreference resolvedBrandingPreference =
-                    brandingPreferenceResolver.resolveBranding(APPLICATION_TYPE, CHILD_APP_ID, DEFAULT_LOCALE);
+                    brandingPreferenceResolver.resolveBranding(APPLICATION_TYPE, CHILD_APP_ID, DEFAULT_LOCALE, false);
 
             Assert.assertEquals(resolvedBrandingPreference.getName(), PARENT_ORG_ID);
             Assert.assertEquals(resolvedBrandingPreference.getLocale(), DEFAULT_LOCALE);
             Assert.assertEquals(resolvedBrandingPreference.getType(), ORGANIZATION_TYPE);
             Assert.assertEquals(resolvedBrandingPreference.getPreference(),
                     getPreferenceFromFile("sample-parent-org-branding-preference-without-display-name.json"));
+        }
+    }
+
+    @Test
+    public void testResolveOrgBrandingRestrictedToPublishedWithPublishedCurrentOrgBranding() throws Exception {
+
+        try (MockedStatic<OSGiDataHolder> mockedOSGiDataHolder = mockStatic(OSGiDataHolder.class)) {
+            mockOSGiDataHolder(mockedOSGiDataHolder);
+            setCarbonContextForTenant(CHILD_ORG_ID, CHILD_TENANT_ID, CHILD_ORG_ID);
+
+            String resourceName =
+                    String.valueOf(CHILD_TENANT_ID).toLowerCase() + RESOURCE_NAME_SEPARATOR + DEFAULT_LOCALE;
+            String resourceId = "61356f5e-e10b-49f2-87a6-f7f48e164374";
+            String resourceFileName = "sample-child-org-branding-preference.json";
+
+            mockBrandingPreferenceRetrieval(resourceName, resourceId, BRANDING_RESOURCE_TYPE, resourceFileName);
+
+            BrandingPreference resolvedBrandingPreference =
+                    brandingPreferenceResolver.resolveBranding(ORGANIZATION_TYPE, CHILD_ORG_ID, DEFAULT_LOCALE, true);
+
+            Assert.assertEquals(resolvedBrandingPreference.getName(), CHILD_ORG_ID);
+            Assert.assertEquals(resolvedBrandingPreference.getLocale(), DEFAULT_LOCALE);
+            Assert.assertEquals(resolvedBrandingPreference.getType(), ORGANIZATION_TYPE);
+            Assert.assertEquals(resolvedBrandingPreference.getPreference(), getPreferenceFromFile(resourceFileName));
+        }
+    }
+
+    @Test
+    public void testResolveOrgBrandingRestrictedToPublishedWithUnpublishedCurrentOrgBranding() throws Exception {
+
+        try (MockedStatic<OSGiDataHolder> mockedOSGiDataHolder = mockStatic(OSGiDataHolder.class)) {
+            mockOSGiDataHolder(mockedOSGiDataHolder);
+            setCarbonContextForTenant(CHILD_ORG_ID, CHILD_TENANT_ID, CHILD_ORG_ID);
+
+            String resourceName =
+                    String.valueOf(CHILD_TENANT_ID).toLowerCase() + RESOURCE_NAME_SEPARATOR + DEFAULT_LOCALE;
+            String resourceId = "61356f5e-e10b-49f2-87a6-f7f48e164374";
+            String resourceFileName = "sample-child-org-unpublished-branding-preference.json";
+
+            mockBrandingPreferenceRetrieval(resourceName, resourceId, BRANDING_RESOURCE_TYPE, resourceFileName);
+
+            assertThrows(BrandingPreferenceMgtClientException.class, () -> {
+                BrandingPreference resolvedBrandingPreference =
+                        brandingPreferenceResolver.resolveBranding(ORGANIZATION_TYPE, CHILD_ORG_ID, DEFAULT_LOCALE,
+                                true);
+            });
+        }
+    }
+
+    @Test
+    public void testResolveOrgBrandingWithUnpublishedCurrentOrgBranding() throws Exception {
+
+        try (MockedStatic<OSGiDataHolder> mockedOSGiDataHolder = mockStatic(OSGiDataHolder.class)) {
+            mockOSGiDataHolder(mockedOSGiDataHolder);
+            setCarbonContextForTenant(CHILD_ORG_ID, CHILD_TENANT_ID, CHILD_ORG_ID);
+
+            String resourceName =
+                    String.valueOf(CHILD_TENANT_ID).toLowerCase() + RESOURCE_NAME_SEPARATOR + DEFAULT_LOCALE;
+            String resourceId = "61356f5e-e10b-49f2-87a6-f7f48e164374";
+            String resourceFileName = "sample-child-org-unpublished-branding-preference.json";
+
+            mockBrandingPreferenceRetrieval(resourceName, resourceId, BRANDING_RESOURCE_TYPE, resourceFileName);
+
+            BrandingPreference resolvedBrandingPreference =
+                    brandingPreferenceResolver.resolveBranding(ORGANIZATION_TYPE, CHILD_ORG_ID, DEFAULT_LOCALE, false);
+
+            /* Even the current org branding is unpublished, resolver should return it
+              since restrictToPublished param is set to false. */
+            Assert.assertEquals(resolvedBrandingPreference.getName(), CHILD_ORG_ID);
+            Assert.assertEquals(resolvedBrandingPreference.getLocale(), DEFAULT_LOCALE);
+            Assert.assertEquals(resolvedBrandingPreference.getType(), ORGANIZATION_TYPE);
+            Assert.assertEquals(resolvedBrandingPreference.getPreference(), getPreferenceFromFile(resourceFileName));
+        }
+    }
+
+    @Test
+    public void testResolveOrgBrandingRestrictedToPublishedWithPublishedParentOrgBranding() throws Exception {
+
+        try (MockedStatic<OSGiDataHolder> mockedOSGiDataHolder = mockStatic(OSGiDataHolder.class)) {
+            mockOSGiDataHolder(mockedOSGiDataHolder);
+            setCarbonContextForTenant(CHILD_ORG_ID, CHILD_TENANT_ID, CHILD_ORG_ID);
+
+            // Mock unpublished current org branding.
+            String currentOrgResourceName =
+                    String.valueOf(CHILD_TENANT_ID).toLowerCase() + RESOURCE_NAME_SEPARATOR + DEFAULT_LOCALE;
+            String currentOrgResourceId = "61356f5e-e10b-49f2-87a6-f7f48e164374";
+            String currentOrgResourceFileName = "sample-child-org-unpublished-branding-preference.json";
+
+            mockBrandingPreferenceRetrieval(currentOrgResourceName,
+                    currentOrgResourceId, BRANDING_RESOURCE_TYPE, currentOrgResourceFileName);
+
+            mockAncestorOrgIdAndAppIdRetrieval();
+
+            // Mock published parent org branding.
+            String parentOrdResourceName =
+                    String.valueOf(PARENT_TENANT_ID).toLowerCase() + RESOURCE_NAME_SEPARATOR + DEFAULT_LOCALE;
+            String parentOrdResourceId = "81356f5e-e10b-49f2-87a6-f7f48e164374";
+            String parentOrdResourceFileName = "sample-parent-org-branding-preference.json";
+
+            when(organizationManager.resolveTenantDomain(PARENT_ORG_ID)).thenReturn(PARENT_ORG_ID);
+            when(organizationManager.getOrganizationDepthInHierarchy(PARENT_ORG_ID)).thenReturn(1);
+
+            mockBrandingPreferenceRetrieval(parentOrdResourceName, parentOrdResourceId, BRANDING_RESOURCE_TYPE,
+                    parentOrdResourceFileName);
+
+            BrandingPreference resolvedBrandingPreference =
+                    brandingPreferenceResolver.resolveBranding(ORGANIZATION_TYPE, CHILD_ORG_ID, DEFAULT_LOCALE, true);
+
+            // Resolver should return published parent org branding since restrictToPublished param is set to true.
+            Assert.assertEquals(resolvedBrandingPreference.getName(), CHILD_ORG_ID);
+            Assert.assertEquals(resolvedBrandingPreference.getLocale(), DEFAULT_LOCALE);
+            Assert.assertEquals(resolvedBrandingPreference.getType(), ORGANIZATION_TYPE);
+            Assert.assertEquals(resolvedBrandingPreference.getPreference(),
+                    getPreferenceFromFile("sample-parent-org-branding-preference-without-display-name.json"));
+        }
+    }
+
+    @Test
+    public void testResolveOrgBrandingRestrictedToPublishedWithNoPublishedBranding() throws Exception {
+
+        try (MockedStatic<OSGiDataHolder> mockedOSGiDataHolder = mockStatic(OSGiDataHolder.class)) {
+            mockOSGiDataHolder(mockedOSGiDataHolder);
+            setCarbonContextForTenant(CHILD_ORG_ID, CHILD_TENANT_ID, CHILD_ORG_ID);
+            String resourceName =
+                    String.valueOf(ROOT_TENANT_ID).toLowerCase() + RESOURCE_NAME_SEPARATOR + DEFAULT_LOCALE;
+            String resourceId = "11356f5e-e10b-49f2-87a6-f7f48e164374";
+            String resourceFileName = "sample-root-org-unpublished-branding-preference.json";
+
+            mockAncestorOrgIdAndAppIdRetrieval();
+
+            when(organizationManager.resolveTenantDomain(ROOT_ORG_ID)).thenReturn(ROOT_TENANT_DOMAIN);
+            when(organizationManager.getOrganizationDepthInHierarchy(ROOT_ORG_ID)).thenReturn(0);
+
+            when(organizationManager.resolveTenantDomain(PARENT_ORG_ID)).thenReturn(PARENT_ORG_ID);
+            when(organizationManager.getOrganizationDepthInHierarchy(PARENT_ORG_ID)).thenReturn(1);
+
+            mockBrandingPreferenceRetrieval(resourceName, resourceId, BRANDING_RESOURCE_TYPE, resourceFileName);
+
+            assertThrows(BrandingPreferenceMgtClientException.class, () -> {
+                BrandingPreference resolvedBrandingPreference =
+                        brandingPreferenceResolver.resolveBranding(ORGANIZATION_TYPE, CHILD_ORG_ID, DEFAULT_LOCALE,
+                                true);
+            });
         }
     }
 

--- a/components/org.wso2.carbon.identity.branding.preference.resolver/src/test/resources/samples/sample-child-app-unpublished-branding-preference.json
+++ b/components/org.wso2.carbon.identity.branding.preference.resolver/src/test/resources/samples/sample-child-app-unpublished-branding-preference.json
@@ -1,0 +1,28 @@
+{
+  "organizationDetails": {
+    "displayName": "XYZ Bank - Colombo",
+    "siteTitle": "Login - Colombo Branch HR Mgt App",
+    "copyrightText": "© 2021 XYZ Bank",
+    "supportEmail": "support@xyzbankcmbsl.com"
+  },
+  "colors": {
+    "primary": "#FF0000"
+  },
+  "images": {
+    "logo": {
+      "imgURL": "https://image/upload/q_auto,f_auto/kentcdodds.com/illustrations/kody_profile_white_mgt_app_cmb",
+      "altText": "XYZ BANK Logo HR Mgt App"
+    },
+    "favicon": {
+      "imgURL": "https://favicons/favicon-16x16.png"
+    }
+  },
+  "urls": {
+    "privacyPolicyURL": "https://coalasports.com/privacy-policy",
+    "termsOfUseURL": "https://coalasports.com/terms-of-service/",
+    "cookiePolicyURL": "https://coalasports.com/privacy-policy/#cookie-policy"
+  },
+  "configs": {
+    "isBrandingEnabled": false
+  }
+}

--- a/components/org.wso2.carbon.identity.branding.preference.resolver/src/test/resources/samples/sample-child-org-unpublished-branding-preference.json
+++ b/components/org.wso2.carbon.identity.branding.preference.resolver/src/test/resources/samples/sample-child-org-unpublished-branding-preference.json
@@ -1,0 +1,28 @@
+{
+  "organizationDetails": {
+    "displayName": "XYZ Bank - Colombo",
+    "siteTitle": "Login - Colombo Branch",
+    "copyrightText": "© 2021 XYZ Bank",
+    "supportEmail": "support@xyzbankcmbsl.com"
+  },
+  "colors": {
+    "primary": "#FF0000"
+  },
+  "images": {
+    "logo": {
+      "imgURL": "https://image/upload/q_auto,f_auto/kentcdodds.com/illustrations/kody_profile_white_cmb",
+      "altText": "XYZ BANK Logo"
+    },
+    "favicon": {
+      "imgURL": "https://favicons/favicon-16x16.png"
+    }
+  },
+  "urls": {
+    "privacyPolicyURL": "https://coalasports.com/privacy-policy",
+    "termsOfUseURL": "https://coalasports.com/terms-of-service/",
+    "cookiePolicyURL": "https://coalasports.com/privacy-policy/#cookie-policy"
+  },
+  "configs": {
+    "isBrandingEnabled": false
+  }
+}

--- a/components/org.wso2.carbon.identity.branding.preference.resolver/src/test/resources/samples/sample-root-org-unpublished-branding-preference.json
+++ b/components/org.wso2.carbon.identity.branding.preference.resolver/src/test/resources/samples/sample-root-org-unpublished-branding-preference.json
@@ -1,0 +1,28 @@
+{
+  "organizationDetails": {
+    "displayName": "XYZ Bank",
+    "siteTitle": "Login - XYZ Bank",
+    "copyrightText": "© 2021 XYZ Bank",
+    "supportEmail": "support@xyzbank.com"
+  },
+  "colors": {
+    "primary": "#FF0000"
+  },
+  "images": {
+    "logo": {
+      "imgURL": "https://image/upload/q_auto,f_auto/kentcdodds.com/illustrations/kody_profile_white",
+      "altText": "XYZ BANK Logo"
+    },
+    "favicon": {
+      "imgURL": "https://favicons/favicon-16x16.png"
+    }
+  },
+  "urls": {
+    "privacyPolicyURL": "https://coalasports.com/privacy-policy",
+    "termsOfUseURL": "https://coalasports.com/terms-of-service/",
+    "cookiePolicyURL": "https://coalasports.com/privacy-policy/#cookie-policy"
+  },
+  "configs": {
+    "isBrandingEnabled": false
+  }
+}

--- a/features/org.wso2.carbon.identity.branding.preference.management.core.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.branding.preference.management.core.server.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.branding.preference.management</groupId>
         <artifactId>identity-branding-preference-management</artifactId>
-        <version>1.1.14</version>
+        <version>1.1.15-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>org.wso2.carbon.identity.branding.preference.management</groupId>
     <artifactId>identity-branding-preference-management</artifactId>
-    <version>1.1.14</version>
+    <version>1.1.15-SNAPSHOT</version>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
     <name>WSO2 Carbon - Branding Preference Management</name>
@@ -38,7 +38,7 @@
         <url>https://github.com/wso2-extensions/identity-branding-preference-management.git</url>
         <developerConnection>scm:git:https://github.com/wso2-extensions/identity-branding-preference-management.git</developerConnection>
         <connection>scm:git:https://github.com/wso2-extensions/identity-branding-preference-management.git</connection>
-        <tag>v1.1.14</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <modules>


### PR DESCRIPTION
## Purpose
- Improve `BrandingPreferenceManagerImpl` and `UIBrandingPreferenceResolverImpl` classes to resolve branding preferences only using published preferences.
- When `restrictToPublished` parameter is set to
    - `true`, resolver will only consider published branding preferences while resolving. 
    - `false`, resolver will consider both published and unpublished branding preferences while resolving. 

## Goals
- Provide nearest published branding at runtime when the resolver is called.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.