### PR TITLE
Add PortalURLResolver

### DIFF
--- a/components/org.wso2.carbon.identity.branding.preference.management.core/pom.xml
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/pom.xml
@@ -66,6 +66,10 @@
             <artifactId>org.wso2.carbon.identity.ai.service.mgt</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.flow.execution.engine</artifactId>
+        </dependency>
+        <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
         </dependency>
@@ -179,7 +183,7 @@
                             org.wso2.carbon.identity.ai.service.mgt.*; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.utils;version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.stratos.common.listeners;version="${carbon.commons.imp.pkg.version}",
-
+                            org.wso2.carbon.identity.flow.execution.engine.*; version="${carbon.identity.package.import.version.range}",
                             org.json; version="${json.wso2.version.range}",
                         </Import-Package>
                     </instructions>

--- a/components/org.wso2.carbon.identity.branding.preference.management.core/pom.xml
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/pom.xml
@@ -185,6 +185,7 @@
                             org.wso2.carbon.stratos.common.listeners;version="${carbon.commons.imp.pkg.version}",
                             org.wso2.carbon.identity.flow.execution.engine.*; version="${carbon.identity.package.import.version.range}",
                             org.json; version="${json.wso2.version.range}",
+                            org.wso2.carbon.identity.core.*; version="${carbon.identity.package.import.version.range}",
                         </Import-Package>
                     </instructions>
                 </configuration>

--- a/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/internal/BrandingPreferenceManagerComponent.java
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/internal/BrandingPreferenceManagerComponent.java
@@ -31,9 +31,11 @@ import org.wso2.carbon.identity.branding.preference.management.core.BrandingPref
 import org.wso2.carbon.identity.branding.preference.management.core.UIBrandingPreferenceResolver;
 import org.wso2.carbon.identity.branding.preference.management.core.ai.BrandingAIPreferenceManager;
 import org.wso2.carbon.identity.branding.preference.management.core.ai.BrandingAIPreferenceManagerImpl;
+import org.wso2.carbon.identity.branding.preference.management.core.listener.PortalURLResolver;
 import org.wso2.carbon.identity.branding.preference.management.core.listener.IdentityTenantMgtListener;
 import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
+import org.wso2.carbon.identity.flow.execution.engine.listener.FlowExecutionListener;
 import org.wso2.carbon.stratos.common.listeners.TenantMgtListener;
 
 /**
@@ -52,13 +54,17 @@ public class BrandingPreferenceManagerComponent {
     protected void activate(ComponentContext context) {
 
         try {
+            BrandingPreferenceManagerImpl brandingPreferenceManager = new BrandingPreferenceManagerImpl();
             context.getBundleContext()
-                    .registerService(BrandingPreferenceManager.class, new BrandingPreferenceManagerImpl(), null);
+                    .registerService(BrandingPreferenceManager.class, brandingPreferenceManager, null);
             context.getBundleContext()
                     .registerService(BrandingAIPreferenceManager.class.getName(), new BrandingAIPreferenceManagerImpl(),
                             null);
             context.getBundleContext()
                     .registerService(TenantMgtListener.class.getName(), new IdentityTenantMgtListener(), null);
+            context.getBundleContext()
+                    .registerService(FlowExecutionListener.class.getName(),
+                            new PortalURLResolver(brandingPreferenceManager), null);
             if (LOG.isDebugEnabled()) {
                 LOG.debug("BrandingPreferenceMgt Service Component is activated.");
             }

--- a/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/internal/BrandingPreferenceManagerComponent.java
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/internal/BrandingPreferenceManagerComponent.java
@@ -31,8 +31,8 @@ import org.wso2.carbon.identity.branding.preference.management.core.BrandingPref
 import org.wso2.carbon.identity.branding.preference.management.core.UIBrandingPreferenceResolver;
 import org.wso2.carbon.identity.branding.preference.management.core.ai.BrandingAIPreferenceManager;
 import org.wso2.carbon.identity.branding.preference.management.core.ai.BrandingAIPreferenceManagerImpl;
-import org.wso2.carbon.identity.branding.preference.management.core.listener.PortalURLResolver;
 import org.wso2.carbon.identity.branding.preference.management.core.listener.IdentityTenantMgtListener;
+import org.wso2.carbon.identity.branding.preference.management.core.listener.PortalURLResolver;
 import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.flow.execution.engine.listener.FlowExecutionListener;
@@ -62,8 +62,7 @@ public class BrandingPreferenceManagerComponent {
                             null);
             context.getBundleContext()
                     .registerService(TenantMgtListener.class.getName(), new IdentityTenantMgtListener(), null);
-            context.getBundleContext()
-                    .registerService(FlowExecutionListener.class.getName(),
+            context.getBundleContext().registerService(FlowExecutionListener.class.getName(),
                             new PortalURLResolver(brandingPreferenceManager), null);
             if (LOG.isDebugEnabled()) {
                 LOG.debug("BrandingPreferenceMgt Service Component is activated.");

--- a/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/listener/PortalURLResolver.java
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/listener/PortalURLResolver.java
@@ -38,7 +38,7 @@ import static org.wso2.carbon.identity.branding.preference.management.core.const
 import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.ORGANIZATION_TYPE;
 
 /**
- * This class is responsible for handling the branding preference management during flow execution.
+ * This class is responsible for injecting the portal URL during flow execution.
  */
 public class PortalURLResolver extends AbstractFlowExecutionListener {
 
@@ -126,7 +126,7 @@ public class PortalURLResolver extends AbstractFlowExecutionListener {
     private static void logMissingSelfSignupUrl(FlowExecutionContext context) {
 
         LOG.debug("Self sign-up URL not configured for tenant: " + context.getTenantDomain() + ". Using default URL: "
-        + DEFAULT_REGISTRATION_PORTAL_URL);
+                + DEFAULT_REGISTRATION_PORTAL_URL);
     }
 
     private String buildDefaultRegistrationUrl() throws URLBuilderException {

--- a/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/listener/PortalURLResolver.java
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/listener/PortalURLResolver.java
@@ -42,7 +42,7 @@ import static org.wso2.carbon.identity.branding.preference.management.core.const
  */
 public class PortalURLResolver extends AbstractFlowExecutionListener {
 
-    private static final Log log = LogFactory.getLog(PortalURLResolver.class);
+    private static final Log LOG = LogFactory.getLog(PortalURLResolver.class);
     private final BrandingPreferenceManagerImpl brandingPreferenceManager;
     public static final String SELF_SIGN_UP_URL = "selfSignUpURL";
     public static final String DEFAULT_REGISTRATION_PORTAL_URL = "/authenticationendpoint/register.do";
@@ -78,7 +78,6 @@ public class PortalURLResolver extends AbstractFlowExecutionListener {
             if (StringUtils.isNotBlank(context.getPortalUrl())) {
                 return true;
             }
-
             String applicationId = context.getApplicationId();
             String tenantDomain = context.getTenantDomain();
             String type = StringUtils.isBlank(applicationId) ? ORGANIZATION_TYPE : APPLICATION_TYPE;
@@ -96,37 +95,38 @@ public class PortalURLResolver extends AbstractFlowExecutionListener {
                     if (StringUtils.isNotBlank(signUpUrl)) {
                         context.setPortalUrl(signUpUrl);
                     } else {
-                        log.debug("Self sign-up URL not configured for tenant: " + tenantDomain +
-                                ". Using default URL.");
+                        logMissingSelfSignupUrl(context);
                         context.setPortalUrl(buildDefaultRegistrationUrl());
                     }
                 }
             }
             if (StringUtils.isBlank(context.getPortalUrl())) {
-                log.debug(String.format("No branding preference found for type: %s, name: %s, tenant: %s." +
-                        " Using default URL.", type, name, tenantDomain));
+                logMissingSelfSignupUrl(context);
                 context.setPortalUrl(buildDefaultRegistrationUrl());
             }
             return true;
         } catch (BrandingPreferenceMgtClientException e) {
-            log.debug("Self sign-up URL not configured for tenant: " + context.getTenantDomain() +
-                    ". Using default URL.");
+            logMissingSelfSignupUrl(context);
             try {
                 context.setPortalUrl(buildDefaultRegistrationUrl());
             } catch (URLBuilderException ex) {
-                log.error("Failed to build default registration URL for tenant: " + context.getTenantDomain(), ex);
+                LOG.error("Failed to build default registration URL for tenant: " + context.getTenantDomain(), ex);
                 return false;
             }
             return true;
-
         } catch (BrandingPreferenceMgtException e) {
-            log.error("Error retrieving branding preference for tenant: " + context.getTenantDomain(), e);
+            LOG.error("Error retrieving branding preference for tenant: " + context.getTenantDomain(), e);
             return false;
-
         } catch (URLBuilderException e) {
-            log.error("Error building default registration portal URL for tenant: " + context.getTenantDomain(), e);
+            LOG.error("Error building default registration portal URL for tenant: " + context.getTenantDomain(), e);
             return false;
         }
+    }
+
+    private static void logMissingSelfSignupUrl(FlowExecutionContext context) {
+
+        LOG.debug("Self sign-up URL not configured for tenant: " + context.getTenantDomain() + ". Using default URL: "
+        + DEFAULT_REGISTRATION_PORTAL_URL);
     }
 
     private String buildDefaultRegistrationUrl() throws URLBuilderException {

--- a/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/listener/PortalURLResolver.java
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/listener/PortalURLResolver.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.branding.preference.management.core.listener;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.branding.preference.management.core.BrandingPreferenceManagerImpl;
+import org.wso2.carbon.identity.branding.preference.management.core.exception.BrandingPreferenceMgtClientException;
+import org.wso2.carbon.identity.branding.preference.management.core.exception.BrandingPreferenceMgtException;
+import org.wso2.carbon.identity.branding.preference.management.core.model.BrandingPreference;
+import org.wso2.carbon.identity.core.ServiceURLBuilder;
+import org.wso2.carbon.identity.core.URLBuilderException;
+import org.wso2.carbon.identity.flow.execution.engine.listener.AbstractFlowExecutionListener;
+import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
+
+import java.util.Map;
+
+import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.APPLICATION_TYPE;
+import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.BRANDING_URLS;
+import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.DEFAULT_LOCALE;
+import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.ORGANIZATION_TYPE;
+
+/**
+ * This class is responsible for handling the branding preference management during flow execution.
+ */
+public class PortalURLResolver extends AbstractFlowExecutionListener {
+
+    private static final Log log = LogFactory.getLog(PortalURLResolver.class);
+    private final BrandingPreferenceManagerImpl brandingPreferenceManager;
+    public static final String SELF_SIGN_UP_URL = "selfSignUpURL";
+    public static final String DEFAULT_REGISTRATION_PORTAL_URL = "/authenticationendpoint/register.do";
+    public static final String REGISTRATION = "REGISTRATION";
+
+    public PortalURLResolver(BrandingPreferenceManagerImpl brandingPreferenceManager) {
+
+        this.brandingPreferenceManager = brandingPreferenceManager;
+    }
+
+    @Override
+    public int getExecutionOrderId() {
+
+        return 4;
+    }
+
+    @Override
+    public int getDefaultOrderId() {
+
+        return 4;
+    }
+
+    @Override
+    public boolean isEnabled() {
+
+        return true;
+    }
+
+    @Override
+    public boolean doPreExecute(FlowExecutionContext context) {
+
+        try {
+            if (StringUtils.isNotBlank(context.getPortalUrl())) {
+                return true;
+            }
+
+            String applicationId = context.getApplicationId();
+            String tenantDomain = context.getTenantDomain();
+            String type = StringUtils.isBlank(applicationId) ? ORGANIZATION_TYPE : APPLICATION_TYPE;
+            String name = StringUtils.isBlank(applicationId) ? tenantDomain : applicationId;
+
+            BrandingPreference preference = brandingPreferenceManager.getBrandingPreference(type, name, DEFAULT_LOCALE);
+
+            if (preference != null) {
+                Map<String, Object> prefMap = (Map<String, Object>) preference.getPreference();
+                Map<String, String> urlMap = (Map<String, String>) prefMap.get(BRANDING_URLS);
+
+                if (REGISTRATION.equals(context.getFlowType())) {
+                    String signUpUrl = (urlMap != null) ? urlMap.get(SELF_SIGN_UP_URL) : null;
+
+                    if (StringUtils.isNotBlank(signUpUrl)) {
+                        context.setPortalUrl(signUpUrl);
+                    } else {
+                        log.debug("Self sign-up URL not configured for tenant: " + tenantDomain +
+                                ". Using default URL.");
+                        context.setPortalUrl(buildDefaultRegistrationUrl());
+                    }
+                }
+            }
+            if (StringUtils.isBlank(context.getPortalUrl())) {
+                log.debug(String.format("No branding preference found for type: %s, name: %s, tenant: %s." +
+                        " Using default URL.", type, name, tenantDomain));
+                context.setPortalUrl(buildDefaultRegistrationUrl());
+            }
+            return true;
+        } catch (BrandingPreferenceMgtClientException e) {
+            log.debug("Self sign-up URL not configured for tenant: " + context.getTenantDomain() +
+                    ". Using default URL.");
+            try {
+                context.setPortalUrl(buildDefaultRegistrationUrl());
+            } catch (URLBuilderException ex) {
+                log.error("Failed to build default registration URL for tenant: " + context.getTenantDomain(), ex);
+                return false;
+            }
+            return true;
+
+        } catch (BrandingPreferenceMgtException e) {
+            log.error("Error retrieving branding preference for tenant: " + context.getTenantDomain(), e);
+            return false;
+
+        } catch (URLBuilderException e) {
+            log.error("Error building default registration portal URL for tenant: " + context.getTenantDomain(), e);
+            return false;
+        }
+    }
+
+    private String buildDefaultRegistrationUrl() throws URLBuilderException {
+
+        return ServiceURLBuilder.create()
+                .addPath(DEFAULT_REGISTRATION_PORTAL_URL)
+                .build()
+                .getAbsolutePublicURL();
+    }
+}

--- a/components/org.wso2.carbon.identity.branding.preference.management.core/src/test/java/org/wso2/carbon/identity/branding/preference/management/core/listener/PortalURLResolverTest.java
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/src/test/java/org/wso2/carbon/identity/branding/preference/management/core/listener/PortalURLResolverTest.java
@@ -47,6 +47,9 @@ import static org.testng.Assert.assertTrue;
 import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.DEFAULT_LOCALE;
 import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.ORGANIZATION_TYPE;
 
+/**
+ * Unit tests for {@link PortalURLResolver}.
+ */
 public class PortalURLResolverTest {
 
     public static final String PORTAL_URL = "https://signup.wso2.com";

--- a/components/org.wso2.carbon.identity.branding.preference.management.core/src/test/java/org/wso2/carbon/identity/branding/preference/management/core/listener/PortalURLResolverTest.java
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/src/test/java/org/wso2/carbon/identity/branding/preference/management/core/listener/PortalURLResolverTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.branding.preference.management.core.listener;
+
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.branding.preference.management.core.BrandingPreferenceManagerImpl;
+import org.wso2.carbon.identity.branding.preference.management.core.exception.BrandingPreferenceMgtClientException;
+import org.wso2.carbon.identity.branding.preference.management.core.exception.BrandingPreferenceMgtException;
+import org.wso2.carbon.identity.branding.preference.management.core.model.BrandingPreference;
+import org.wso2.carbon.identity.core.ServiceURL;
+import org.wso2.carbon.identity.core.ServiceURLBuilder;
+import org.wso2.carbon.identity.core.URLBuilderException;
+import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.DEFAULT_LOCALE;
+import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.ORGANIZATION_TYPE;
+
+public class PortalURLResolverTest {
+
+    public static final String PORTAL_URL = "https://signup.wso2.com";
+    @Mock
+    private BrandingPreferenceManagerImpl brandingPreferenceManager;
+
+    @Mock
+    private FlowExecutionContext flowContext;
+
+    @Mock
+    private BrandingPreference brandingPreference;
+
+    private PortalURLResolver resolver;
+
+    @BeforeMethod
+    public void setup() {
+
+        MockitoAnnotations.openMocks(this);
+        resolver = new PortalURLResolver(brandingPreferenceManager);
+    }
+
+    @Test
+    public void skipSetPortalUrl() {
+
+        when(flowContext.getPortalUrl()).thenReturn("https://existing.url");
+
+        boolean result = resolver.doPreExecute(flowContext);
+
+        assertTrue(result);
+        verify(flowContext, never()).setPortalUrl(any());
+    }
+
+    @Test
+    public void validPref_setsCustomSignupUrl() throws Exception {
+
+        when(flowContext.getPortalUrl()).thenReturn(null);
+        when(flowContext.getApplicationId()).thenReturn(null);
+        when(flowContext.getTenantDomain()).thenReturn("wso2.com");
+        when(flowContext.getFlowType()).thenReturn("REGISTRATION");
+
+        Map<String, String> urlsMap = new HashMap<>();
+        urlsMap.put("selfSignUpURL", PORTAL_URL);
+        Map<String, Object> prefMap = new HashMap<>();
+        prefMap.put("urls", urlsMap);
+
+        when(brandingPreferenceManager.getBrandingPreference(ORGANIZATION_TYPE, "wso2.com", DEFAULT_LOCALE))
+                .thenReturn(brandingPreference);
+        when(brandingPreference.getPreference()).thenReturn(prefMap);
+
+        try (MockedStatic<ServiceURLBuilder> serviceURLBuilder = mockStatic(ServiceURLBuilder.class)) {
+
+            mockServiceURLBuilder();
+            boolean result = resolver.doPreExecute(flowContext);
+            assertTrue(result);
+            verify(flowContext).setPortalUrl(PORTAL_URL);
+        }
+    }
+
+    @Test
+    public void fallBackToDefaultUrl() throws Exception {
+
+        when(flowContext.getPortalUrl()).thenReturn("");
+        when(flowContext.getApplicationId()).thenReturn(null);
+        when(flowContext.getTenantDomain()).thenReturn("wso2.com");
+        when(flowContext.getFlowType()).thenReturn("REGISTRATION");
+
+        when(brandingPreferenceManager.getBrandingPreference(ORGANIZATION_TYPE, "wso2.com", DEFAULT_LOCALE))
+                .thenReturn(null);
+
+        try (MockedStatic<ServiceURLBuilder> serviceURLBuilder = mockStatic(ServiceURLBuilder.class)) {
+
+            mockServiceURLBuilder();
+            boolean result = resolver.doPreExecute(flowContext);
+            assertTrue(result);
+        }
+    }
+
+    @Test
+    public void prefWithoutSelfSignupUrl() throws Exception {
+
+        when(flowContext.getPortalUrl()).thenReturn(null);
+        when(flowContext.getApplicationId()).thenReturn(null);
+        when(flowContext.getTenantDomain()).thenReturn("wso2.com");
+        when(flowContext.getFlowType()).thenReturn("REGISTRATION");
+
+        Map<String, Object> prefMap = new HashMap<>();
+        prefMap.put("urls", new HashMap<>());
+        when(brandingPreferenceManager.getBrandingPreference(ORGANIZATION_TYPE, "wso2.com", DEFAULT_LOCALE))
+                .thenReturn(brandingPreference);
+        when(brandingPreference.getPreference()).thenReturn(prefMap);
+
+        try (MockedStatic<ServiceURLBuilder> serviceURLBuilder = mockStatic(ServiceURLBuilder.class)) {
+
+            mockServiceURLBuilder();
+            boolean result = resolver.doPreExecute(flowContext);
+            assertTrue(result);
+        }
+    }
+
+    private static void mockServiceURLBuilder() throws URLBuilderException {
+
+        ServiceURLBuilder serviceURLBuilderMock = mock(ServiceURLBuilder.class);
+        when(ServiceURLBuilder.create()).thenReturn(serviceURLBuilderMock);
+        when(serviceURLBuilderMock.addPath(anyString())).thenReturn(serviceURLBuilderMock);
+        ServiceURL serviceURL = mock(ServiceURL.class);
+        when(serviceURLBuilderMock.build()).thenReturn(serviceURL);
+        String url = "https://default.url";
+        when(serviceURL.getAbsolutePublicURL()).thenReturn(url);
+    }
+
+    @Test
+    public void clientExceptionForMissingConfig() throws Exception {
+
+        when(flowContext.getPortalUrl()).thenReturn(null);
+        when(flowContext.getApplicationId()).thenReturn(null);
+        when(flowContext.getTenantDomain()).thenReturn("foo.com");
+        when(flowContext.getFlowType()).thenReturn("REGISTRATION");
+
+        BrandingPreferenceMgtClientException ex = new BrandingPreferenceMgtClientException("Not configured",
+                "BRAND-60001");
+        when(brandingPreferenceManager.getBrandingPreference(ORGANIZATION_TYPE, "foo.com",
+                DEFAULT_LOCALE)).thenThrow(ex);
+
+        try (MockedStatic<ServiceURLBuilder> serviceURLBuilder = mockStatic(ServiceURLBuilder.class)) {
+
+            mockServiceURLBuilder();
+            boolean result = resolver.doPreExecute(flowContext);
+            assertTrue(result);
+        }
+    }
+
+    @Test
+    public void internalErrorDuringURLResolving() throws Exception {
+
+        when(flowContext.getPortalUrl()).thenReturn(null);
+        when(flowContext.getApplicationId()).thenReturn(null);
+        when(flowContext.getTenantDomain()).thenReturn("foo.com");
+        when(flowContext.getFlowType()).thenReturn("REGISTRATION");
+
+        when(brandingPreferenceManager.getBrandingPreference(any(), any(), any()))
+                .thenThrow(new BrandingPreferenceMgtException("Something broke", "BRAND-600xx"));
+
+        boolean result = resolver.doPreExecute(flowContext);
+
+        assertFalse(result);
+    }
+}

--- a/components/org.wso2.carbon.identity.branding.preference.management.core/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/src/test/resources/testng.xml
@@ -29,6 +29,7 @@
             <class name="org.wso2.carbon.identity.branding.preference.management.core.dao.impl.OrgCustomContentDAOImplTest"/>
             <class name="org.wso2.carbon.identity.branding.preference.management.core.dao.impl.CustomContentPersistentDAOImplTest"/>
             <class name="org.wso2.carbon.identity.branding.preference.management.core.listener.IdentityTenantMgtListenerTest"/>
+            <class name="org.wso2.carbon.identity.branding.preference.management.core.listener.PortalURLResolverTest"/>
         </classes>
     </test>
 </suite>

--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,11 @@
                 <artifactId>org.wso2.carbon.identity.ai.service.mgt</artifactId>
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.flow.execution.engine</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
 
             <!-- Org Management related dependencies -->
             <dependency>


### PR DESCRIPTION
## Purpose

Add PortalURLResolver to populate the customized portal URL in the context for each flow. Currently flow type is hardcoded in the listener itself.

## Issue

https://github.com/wso2/product-is/issues/24285
