### PR TITLE
Add content size validation for custom contents

### DIFF
--- a/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/constant/BrandingPreferenceMgtConstants.java
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/constant/BrandingPreferenceMgtConstants.java
@@ -49,6 +49,9 @@ public class BrandingPreferenceMgtConstants {
     public static final String BRANDING_URLS = "urls";
     public static final String CONFIGS = "configs";
     public static final String IS_BRANDING_ENABLED = "isBrandingEnabled";
+    public static final String CUSTOM_CONTENT_SIZE_LIMIT_CONFIG_KEY =
+            "BrandingConfiguration.CustomContent.MaxFileSize";
+    public static final int CUSTOM_CONTENT_SIZE_LIMIT_DEFAULT = 1048576; // 1 MB
 
     public static final String RESOURCE_NOT_EXISTS_ERROR_CODE = "CONFIGM_00017";
     public static final String RESOURCES_NOT_EXISTS_ERROR_CODE = "CONFIGM_00020";
@@ -151,7 +154,9 @@ public class BrandingPreferenceMgtConstants {
         ERROR_CODE_ERROR_GETTING_APP_CUSTOM_LAYOUT_CONTENT("BRANDINGM_00045",
                 "Error while getting app-level custom layout content for application id: %s."),
         ERROR_CODE_MANDATORY_COMPONENT_NOT_FOUND("BRANDINGM_00047",
-                "Mandatory component '%s' not found in the custom layout html content.");
+                "Mandatory component '%s' not found in the custom layout html content."),
+        ERROR_CODE_MAXIMUM_CUSTOM_CONTENT_SIZE_EXCEEDED("BRANDINGM_00048",
+                "Maximum custom content length exceeded. The maximum allowed size is %s bytes.");
 
         private final String code;
         private final String message;


### PR DESCRIPTION
This pull request introduces functionality to validate the size of custom branding content, ensuring it adheres to a configurable maximum size limit. It includes updates to constants, utility methods, and unit tests to support this feature.

### Feature Enhancements:
* Added a new constant `CUSTOM_CONTENT_SIZE_LIMIT_CONFIG_KEY` for configuring the maximum file size of custom branding content, with a default limit set to 1 MB (`CUSTOM_CONTENT_SIZE_LIMIT_DEFAULT`). (`[components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/constant/BrandingPreferenceMgtConstants.javaR52-R54](diffhunk://#diff-9e0baea403df0f84757a4108ab62d204f02ccd23590c63ef6a6d5eb55f7cca90R52-R54)`)
* Introduced a new error message `ERROR_CODE_MAXIMUM_CUSTOM_CONTENT_SIZE_EXCEEDED` to handle cases where the custom content size exceeds the allowed limit. (`[components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/constant/BrandingPreferenceMgtConstants.javaL154-R159](diffhunk://#diff-9e0baea403df0f84757a4108ab62d204f02ccd23590c63ef6a6d5eb55f7cca90L154-R159)`)
* Implemented the `validateCustomLayoutContentSize` method in `BrandingPreferenceMgtUtils` to enforce the size validation logic for HTML, CSS, and JS content. (`[components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/util/BrandingPreferenceMgtUtils.javaR122-R151](diffhunk://#diff-b10d593b01aa5734008b38756e9e12428bb787b7382cda84191a628f96b110bdR122-R151)`)

### Unit Test Updates:
* Enhanced the `brandingPreferenceValidationDataProvider` to include test cases for validating content size limits. (`[components/org.wso2.carbon.identity.branding.preference.management.core/src/test/java/org/wso2/carbon/identity/branding/preference/management/core/util/BrandingPreferenceMgtUtilsTest.javaL111-R123](diffhunk://#diff-7227d06c701f427e91b8acfdfa527bfc821067b5603c050cf463b943435e5895L111-R123)`)
* Added a new test method `testIsValidBrandingPreferenceWithChangeContentSize` to verify behavior with different content sizes and invalid configuration values. (`[components/org.wso2.carbon.identity.branding.preference.management.core/src/test/java/org/wso2/carbon/identity/branding/preference/management/core/util/BrandingPreferenceMgtUtilsTest.javaR139-R165](diffhunk://#diff-7227d06c701f427e91b8acfdfa527bfc821067b5603c050cf463b943435e5895R139-R165)`)
* Created a helper method `generateLargeString` to produce large strings for testing size validation logic. (`[components/org.wso2.carbon.identity.branding.preference.management.core/src/test/java/org/wso2/carbon/identity/branding/preference/management/core/util/BrandingPreferenceMgtUtilsTest.javaR319-R336](diffhunk://#diff-7227d06c701f427e91b8acfdfa527bfc821067b5603c050cf463b943435e5895R319-R336)`)

### Related Issue
- https://github.com/wso2/product-is/issues/23692