### PR TITLE
Update default portal URLs for registration and recovery

### DIFF
--- a/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/util/BrandingPreferenceMgtUtils.java
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/util/BrandingPreferenceMgtUtils.java
@@ -71,8 +71,8 @@ import static org.wso2.carbon.identity.flow.mgt.Constants.FlowTypes.REGISTRATION
  */
 public class BrandingPreferenceMgtUtils {
 
-    public static final String DEFAULT_REGISTRATION_PORTAL_URL = "/authenticationendpoint/register.do";
-    public static final String DEFAULT_RECOVERY_PORTAL_URL = "/authenticationendpoint/recovery.do";
+    public static final String DEFAULT_REGISTRATION_PORTAL_URL = "/accounts/register";
+    public static final String DEFAULT_RECOVERY_PORTAL_URL = "/accounts/recovery";
     private static final Log log = LogFactory.getLog(BrandingPreferenceMgtUtils.class);
 
     /**


### PR DESCRIPTION
## Purpose
This pull request updates the default URLs for registration and recovery portals in the branding preference management utility. The change aligns the endpoints with the newer `/accounts` path conventions.

Branding preference URL updates:

* Changed `DEFAULT_REGISTRATION_PORTAL_URL` from `/authenticationendpoint/register.do` to `/accounts/register` in `BrandingPreferenceMgtUtils.java`.
* Changed `DEFAULT_RECOVERY_PORTAL_URL` from `/authenticationendpoint/recovery.do` to `/accounts/recovery` in `BrandingPreferenceMgtUtils.java`.

## Related Issue
- https://github.com/wso2/product-is/issues/24937