### PR TITLE
Switch invited user registration to use register endpoint

### DIFF
--- a/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/util/BrandingPreferenceMgtUtils.java
+++ b/components/org.wso2.carbon.identity.branding.preference.management.core/src/main/java/org/wso2/carbon/identity/branding/preference/management/core/util/BrandingPreferenceMgtUtils.java
@@ -64,6 +64,7 @@ import static org.wso2.carbon.identity.branding.preference.management.core.const
 import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.RECOVERY_PORTAL_URL;
 import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.RESOURCE_NAME_SEPARATOR;
 import static org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants.SELF_SIGN_UP_URL;
+import static org.wso2.carbon.identity.flow.mgt.Constants.FlowTypes.INVITED_USER_REGISTRATION;
 import static org.wso2.carbon.identity.flow.mgt.Constants.FlowTypes.REGISTRATION;
 
 /**
@@ -417,7 +418,9 @@ public class BrandingPreferenceMgtUtils {
     private static String buildDefaultPortalUrl(String flowType) throws URLBuilderException {
 
         ServiceURLBuilder builder = ServiceURLBuilder.create();
-        String path = REGISTRATION.getType().equalsIgnoreCase(flowType) ? DEFAULT_REGISTRATION_PORTAL_URL
+        String path = (REGISTRATION.getType().equalsIgnoreCase(flowType)
+                || INVITED_USER_REGISTRATION.getType().equalsIgnoreCase(flowType))
+                ? DEFAULT_REGISTRATION_PORTAL_URL
                 : DEFAULT_RECOVERY_PORTAL_URL;
         return builder.addPath(path).build().getAbsolutePublicURL();
     }


### PR DESCRIPTION
## Related Issue
- https://github.com/wso2/product-is/issues/25437

## Purpose
This pull request updates the logic for determining the default portal URL in the branding preference management utility, specifically to support both regular and invited user registration flows.

Enhancements to flow support:

* Added `INVITED_USER_REGISTRATION` from `org.wso2.carbon.identity.flow.mgt.Constants.FlowTypes` to the imports in `BrandingPreferenceMgtUtils.java`, enabling recognition of invited user registration flows.
* Updated the `buildDefaultPortalUrl` method to treat both `REGISTRATION` and `INVITED_USER_REGISTRATION` flow types as registration flows, ensuring they use the registration portal URL rather than the recovery portal URL.